### PR TITLE
Add pairrm baseline training and eval code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,13 @@
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+		// Install cuda
+		"ghcr.io/devcontainers/features/nvidia-cuda:1": {
+			"installToolkit": true
+		}
+	},
+
 
 	// Enable GPU passthrough if a GPU is available
 	"hostRequirements": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,11 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
+	// Enable GPU passthrough if a GPU is available
+	"hostRequirements": {
+		"gpu": "optional"
+	},
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,5 @@ wandb/
 results_evaluators
 .langchain.db
 client_configs/client_configs.yaml
+
+pairrm_cache

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ icai-exp -cd exp/configs/prior-experiment prior_cache_path='exp/outputs/prior-ex
 >[!WARNING]
 > Note that there is no strict config consistency check between cache and new experiment - thus use with caution, only using caches from prior experiments with identical configs.
 
+### Running the PairRM baseline
+
+The PairRM baseline experiment can be reproduced using the following command (assuming the processed data is in the standard location):
+
+```
+bash tools/baselines/pairrm/run.sh data/processed
+```
+
 ## Development
 
 ### Dev installation

--- a/tools/baselines/pairrm/convert_data.py
+++ b/tools/baselines/pairrm/convert_data.py
@@ -1,0 +1,132 @@
+"""Convert a dataset to the format pairrm expects."""
+
+import json
+import argparse
+
+from inverse_cai.experiment.core import setup_data
+
+
+# Unfortunately our datasets merged the instruction and output into one field,
+# while the pairrm format expects them to be separate. We need to split them
+# using a heuristic.
+
+
+def split_instruction_output(text, output_delim, instruction_prefix):
+    assert output_delim in text, f"Output delimiter not found. Text: {text}"
+    split_results = text.split(output_delim)
+    assert (
+        len(split_results) == 2
+    ), "Output delimiter found more than once, no robust parsing possible. Text: {text}"
+    instruction, output = split_results
+    assert instruction.startswith(instruction_prefix)
+    return instruction[len(instruction_prefix) :].strip(), output.strip()
+
+
+def split_instruction_output_synthetic(text):
+    return split_instruction_output(
+        text, output_delim="\n\nOutput: ", instruction_prefix="Instruction: "
+    )
+
+
+def split_instruction_output_alpacaeval(text):
+    return split_instruction_output(
+        text, output_delim="\n\nAssistant:\n", instruction_prefix="Instruction:\n"
+    )
+
+
+def split_instruction_output_heuristic(text):
+    try:
+        return split_instruction_output_synthetic(text)
+    except AssertionError:
+        return split_instruction_output_alpacaeval(text)
+
+
+# See this for reference on the format:
+# https://github.com/timokau/LLM-Blender/blob/82ef7c6067bb85dfceeff7dd31678c4546e2a2a4/data/mini_preferences/all_train.json
+def df_data_to_pairrm_json(data, output_path):
+    prefs = []
+    for i in data.index:
+        text_a = data["text_a"][i]
+        text_b = data["text_b"][i]
+
+        instr, candidate_text_a = split_instruction_output_heuristic(text_a)
+        instr_b, candidate_text_b = split_instruction_output_heuristic(text_b)
+        assert instr_b == instr
+
+        prefs.append(
+            {
+                "id": f"pref_{i}",
+                # This dataset differentiates between instruction and input. The
+                # intention is likely that instruction is something like "Summarize
+                # the following text", and input is the text to summarize. We do not
+                # have this distinction in our data, so we leave input empty.
+                "instruction": instr,
+                "input": "",
+                "candidates": [
+                    {
+                        "text": candidate_text_a,
+                        "model": "human",
+                        "decoding_method": "preference",
+                        "scores": {
+                            "human_preference": (
+                                1.0 if data["preferred_text"][i] == "text_a" else 0.0
+                            )
+                        },
+                    },
+                    {
+                        "text": candidate_text_b,
+                        "model": "human",
+                        "decoding_method": "preference",
+                        "scores": {
+                            "human_preference": (
+                                1.0 if data["preferred_text"][i] == "text_b" else 0.0
+                            )
+                        },
+                    },
+                ],
+            }
+        )
+
+    with open(output_path, "w") as f:
+        json.dump(prefs, f, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Prepare data for fine-tuning a pair_rm model."
+    )
+    parser.add_argument(
+        "input_icai_csv", type=str, help="Data to prepare in ICAI's csv format."
+    )
+    parser.add_argument(
+        "output_pairrm_json",
+        type=str,
+        help="Path to save the output json file in the format expected by LLm Blender.",
+    )
+    parser.add_argument(
+        "--invert_labels", action="store_true", help="Invert the labels."
+    )
+    parser.add_argument(
+        "--data_len", type=int, default=None, help="Length of the data to use."
+    )
+    parser.add_argument(
+        "--data_start_index",
+        type=int,
+        default=0,
+        help="Start index of the data to use.",
+    )
+
+    args = parser.parse_args()
+
+    data = setup_data(
+        data_path=args.input_icai_csv,
+        invert_labels=args.invert_labels,
+        data_len=args.data_len,
+        data_start_index=args.data_start_index,
+    )
+
+    df_data_to_pairrm_json(data, args.output_pairrm_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/baselines/pairrm/fine_tune_pairrm.sh
+++ b/tools/baselines/pairrm/fine_tune_pairrm.sh
@@ -1,0 +1,88 @@
+ #!/bin/bash
+
+ # Fine-tune PairRanker on a preference dataset.
+
+ # This was adapted from train_ranker.sh in LLM-Blender.
+ # https://github.com/yuchenlin/LLM-Blender/blob/33204d2712944b6b17996f7c079e74cd963ccc7c/train_ranker.sh
+
+if [ "$#" -lt 4 ] || [ "$#" -gt 5 ]; then
+    echo "Usage: $0 <target_dir> <data_base> <data_name> <num_epochs> [cache_dir]"
+    exit 1
+fi
+
+target_dir=$(realpath "$1")
+data_base=$(realpath "$2")
+
+data_name="$3"
+num_train_epochs="$4" # PairRanker uses 5
+cache_dir="${5:-pairrm_cache}"
+mkdir -p "$cache_dir"
+
+base_checkpoint="hf:llm-blender/PairRM"
+
+backbone_type="deberta"
+backbone_name="microsoft/deberta-v3-large"
+n_gpu=1
+
+learning_rate=5e-6 # PairRanker uses 1e-5
+
+per_device_eval_batch_size=1
+per_device_train_batch_size=1
+gradient_accumulation_steps=1
+source_maxlength=1224
+candidate_maxlength=412
+max_grad_norm=10e10 # set a large value to disable gradient clipping
+fp16=True # whether to use fp16
+
+do_train=True
+if [ ${num_train_epochs} -eq 0 ]; then
+    do_train=False
+fi
+
+LAUNCH_CMD="python3 -m llm_blender.train_ranker"
+
+train_data_path="${data_base}/${data_name}/train.json"
+dev_data_path="${data_base}/${data_name}/val.json"
+test_data_path="${data_base}/${data_name}/test.json"
+run_name="${data_name}-${num_train_epochs}epochs"
+
+
+pushd "$cache_dir" # Fine-tuning from a huggingface model leaves a hf_models dir in PWD.
+# Run training
+${LAUNCH_CMD} \
+    --ranker_type "pairranker" \
+    --model_type ${backbone_type} \
+    --model_name ${backbone_name} \
+    --run_name ${run_name} \
+    --train_data_path ${train_data_path} \
+    --eval_data_path ${dev_data_path} \
+    --test_data_path ${test_data_path} \
+    --n_candidates -1 \
+    --candidate_model "" \
+    --candidate_decoding_method "" \
+    --using_metrics "human_preference" \
+    --learning_rate ${learning_rate} \
+    --source_maxlength ${source_maxlength} \
+    --candidate_maxlength ${candidate_maxlength} \
+    --per_device_train_batch_size ${per_device_train_batch_size} \
+    --per_device_eval_batch_size ${per_device_eval_batch_size} \
+    --gradient_accumulation_steps ${gradient_accumulation_steps} \
+    --num_train_epochs ${num_train_epochs} \
+    --do_train "$do_train" \
+    --do_eval True \
+    --do_predict True \
+    --inference_mode "bubble" \
+    --load_checkpoint "$base_checkpoint" \
+    --max_grad_norm ${max_grad_norm} \
+    --max_train_data_size -1\
+    --max_eval_data_size -1 \
+    --max_predict_data_size -1 \
+    --max_grad_norm ${max_grad_norm} \
+    --fp16 ${fp16} \
+    --num_pos 5 \
+    --num_neg 5 \
+    --loss_type "instructgpt" \
+    --sub_sampling_mode "all_pair" \
+    --output_dir "$target_dir/${run_name}" \
+    --overwrite_output_dir True
+popd

--- a/tools/baselines/pairrm/prepare_data.sh
+++ b/tools/baselines/pairrm/prepare_data.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Convert the datasets needed for the experiments in the paper to the format
+# used by PairRM.
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <data_basedir> <target_dir>"
+    exit 1
+fi
+
+data_basedir="$1" # Should point to the processed data, e.g., ./data/processed
+tgt_dir="$2"
+script_dir=$(dirname "$0")
+prepdata="python3 $script_dir/convert_data.py"
+
+# Generate synthetic-aligned (same data for val/train/test)
+target_base="$tgt_dir/icai_synthetic_aligned"
+mkdir -p "$target_base"
+src="$data_basedir/synthetic/synthetic_data_aligned_vqvtb.csv"
+$prepdata "$src" "${target_base}/val.json"
+$prepdata "$src" "${target_base}/train.json"
+$prepdata "$src" "${target_base}/test.json"
+
+# Generate synthetic-unaligned (same data for val/train/test)
+target_base="$tgt_dir/icai_synthetic_unaligned"
+mkdir -p "$target_base"
+src="$data_basedir/synthetic/synthetic_data_aligned_vqvtb.csv"
+$prepdata --invert_labels "$src" "${target_base}/val.json"
+$prepdata --invert_labels "$src" "${target_base}/train.json"
+$prepdata --invert_labels "$src" "${target_base}/test.json"
+
+# Generate synthetic-orthogonal
+target_base="$tgt_dir/icai_synthetic_orthogonal"
+mkdir -p "$target_base"
+src="$data_basedir/synthetic/synthetic_data_orthogonal_adcbg.csv"
+$prepdata "$src" "${target_base}/val.json"
+$prepdata "$src" "${target_base}/train.json"
+$prepdata "$src" "${target_base}/test.json"
+
+# Generate alpacaeval-aligned full (val/train/test: 32/292/324)
+target_base="$tgt_dir/icai_alpacaeval_full_aligned"
+mkdir -p "$target_base"
+src="$data_basedir/tatsu_lab/alpacaeval_goldcrossannotations_rand.csv"
+$prepdata --data_start_index=0 --data_len=32 "$src" "${target_base}/val.json"
+$prepdata --data_start_index=32 --data_len=292 "$src" "${target_base}/train.json"
+$prepdata --data_start_index=324 --data_len=324 "$src" "${target_base}/test.json"
+
+# Generate alpacaeval-unaligned full (val/train/test: 32/292/324)
+target_base="$tgt_dir/icai_alpacaeval_full_unaligned"
+mkdir -p "$target_base"
+src="$data_basedir/tatsu_lab/alpacaeval_goldcrossannotations_rand.csv"
+$prepdata --invert_labels --data_start_index=0 --data_len=32 "$src" "${target_base}/val.json"
+$prepdata --invert_labels --data_start_index=32 --data_len=292 "$src" "${target_base}/train.json"
+$prepdata --invert_labels --data_start_index=324 --data_len=324 "$src" "${target_base}/test.json"
+
+# Generate alpacaeval-aligned small (val/train/test: 10/55/65)
+target_base="$tgt_dir/icai_alpacaeval_small_aligned"
+mkdir -p "$target_base"
+src="$data_basedir/tatsu_lab/alpacaeval_goldcrossannotations_rand.csv"
+$prepdata --data_start_index=0 --data_len=10 "$src" "${target_base}/val.json"
+$prepdata --data_start_index=10 --data_len=55 "$src" "${target_base}/train.json"
+$prepdata --data_start_index=200 --data_len=65  "$src" "${target_base}/test.json"
+
+# Generate alpacaeval-unaligned small (val/train/test: 10/55/65)
+target_base="$tgt_dir/icai_alpacaeval_small_unaligned"
+mkdir -p "$target_base"
+src="$data_basedir/tatsu_lab/alpacaeval_goldcrossannotations_rand.csv"
+$prepdata --invert_labels --data_start_index=0 --data_len=10 "$src" "${target_base}/val.json"
+$prepdata --invert_labels --data_start_index=10 --data_len=55 "$src" "${target_base}/train.json"
+$prepdata --invert_labels --data_start_index=200 --data_len=65  "$src" "${target_base}/test.json"

--- a/tools/baselines/pairrm/run.sh
+++ b/tools/baselines/pairrm/run.sh
@@ -1,0 +1,98 @@
+#! /bin/bash
+
+# Reproduce the pairrm fine-tuning results. This runs the entire pipeline,
+# including data preparation, base-model fetching, fine-tuning, and evaluation.
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 SOURCE_DATA_DIR [PAIRRM_DATA_DIR] [LOG_DIR] [MODEL_DIR]"
+    echo "SOURCE_DATA_DIR: Directory containing the processed data"
+    echo "PAIRRM_DATA_DIR: Directory to store the PairRM data (default: a temporary directory)"
+    echo "LOG_DIR: Directory to store the logs (default: a temporary directory)"
+    echo "MODEL_DIR: Directory to store the fine-tuned models (default: a temporary directory)"
+    exit 1
+fi
+
+temp_dir=$(mktemp -d)
+SOURCE_DATA_DIR="$1"
+PAIRRM_DATA_DIR="${2:-$temp_dir/data}"
+LOG_DIR="${3:-$temp_dir/logs}"
+MODEL_DIR="${4:-$temp_dir/models}"
+mkdir -p "$LOG_DIR"
+
+EPOCHS=5    
+
+script_dir=$(dirname "$0")
+
+if ! python3 -c "import llm_blender.train_ranker"; then
+    echo "Could not import the `train_ranker` module." >&2
+    echo "Please install the LLM-Blender fork:" >&2
+    # If https://github.com/yuchenlin/LLM-Blender/pull/32 gets merged we can use the official repo.
+    echo 'pip install "llm_blender[train,eval] @ git+https://github.com/timokau/LLM-Blender.git@icai-pairrm-finetune"' >&2
+    exit 1
+fi
+
+# Check if data already exists
+if [ -d "$PAIRRM_DATA_DIR" ]; then
+    echo "Data already exists in $PAIRRM_DATA_DIR"
+    echo "Delete it (d) or skip generation (s)? [d/s]"
+    read -r delete_data
+    if [ "$delete_data" = "d" ]; then
+        rm -r "$PAIRRM_DATA_DIR"
+    elif [ "$delete_data" = "s" ]; then
+        echo "Skipping data generation"
+    else
+        echo "Invalid input"
+        exit 1
+    fi
+fi
+if [ ! -d "$PAIRRM_DATA_DIR" ]; then
+    echo "Preparing PairRM data in $PAIRRM_DATA_DIR"
+    log_file="$LOG_DIR/prepare_data.log"
+    echo "Logging to $log_file"
+    time bash "$script_dir/prepare_data.sh" "$SOURCE_DATA_DIR" "$PAIRRM_DATA_DIR" >"$log_file"
+    echo "Done generating PairRM data"
+fi
+
+echo "Evaluating untuned PairRM. Logging to $LOG_DIR"
+for ds in $(ls "$PAIRRM_DATA_DIR"); do
+    log_file="$LOG_DIR/$ds-no-tune.log"
+    echo "Evaluating on $ds. Logging to $log_file."
+    time bash "$script_dir/fine_tune_pairrm.sh" "$MODEL_DIR" "$PAIRRM_DATA_DIR" "$ds" 0 >"$log_file" 2>&1
+done
+
+echo "Fine-tuning PairRM. Logging to $LOG_DIR. Saving models to $MODEL_DIR"
+mkdir -p "$MODEL_DIR"
+for ds in $(ls "$PAIRRM_DATA_DIR"); do
+    log_file="$LOG_DIR/$ds-fine-tune.log"
+    echo "Fine-tuning on $ds. Logging to $log_file."
+    time bash "$script_dir/fine_tune_pairrm.sh" "$MODEL_DIR" "$PAIRRM_DATA_DIR" "$ds" "$EPOCHS" >"$log_file" 2>&1
+done
+
+for ds in $(ls "$PAIRRM_DATA_DIR"); do
+    tune_log_file="$LOG_DIR/$ds-fine-tune.log"
+    eval_log_file="$LOG_DIR/$ds-no-tune.log"
+    # Extract "metric_1" of "test_sel" ("selection", i.e., preference choice,
+    # on test set). metric_1 is accuracy, see compute_metrics_for_pairranker in
+    # llm_blender/pair_ranker/trainer.py, which computes the mean "score" (1 if
+    # correct choice, 0 otherwise) of the chosen output, which equals the
+    # accuracy.
+    tune_accuracy=$(sed -n "s/.*'test_sel': {'metric_1': \([0-9.]\+\)}.*/\1/p" "$tune_log_file")
+    no_tune_accuracy=$(sed -n "s/.*'test_sel': {'metric_1': \([0-9.]\+\)}.*/\1/p" "$eval_log_file")
+    echo "Fine-tuned $ds: $tune_accuracy. No tuning: $no_tune_accuracy"
+done
+
+
+echo "Done fine-tuning PairRM. Logs are in $LOG_DIR. Data is in $PAIRRM_DATA_DIR."
+
+echo "NOTE: This script left data behind in the following locations. You may want to delete it if you do not need it anymore."
+echo "Data: $PAIRRM_DATA_DIR"
+echo "Logs: $LOG_DIR"
+echo "Models: $MODEL_DIR"
+echo "Delete all? [y/N]"
+read -r delete_temp
+if [ "$delete_temp" = "y" ]; then
+    rm -r "$PAIRRM_DATA_DIR" "$LOG_DIR" "$MODEL_DIR"
+	rmdir "$temp_dir"
+fi


### PR DESCRIPTION
This makes it possible to run the pairrm baseline experiments with a single command (`bash tools/baselines/pairrm/run.sh data/processed`).

The baseline depends on my forked version of LLM-Blender. Related PR: https://github.com/yuchenlin/LLM-Blender/pull/32