### PR TITLE
Add standardized annotated pairs data format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Check formatting with Black
-        run: black --check --version && black --check .
+        run: black --check --version && black --check . --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inverse-cai"
-version = "0.2.1"
+version = "0.3.0"
 authors = [
   { name="rdnfn", email="hi@arduin.io" },
   { name="timokau", email="" },
@@ -70,7 +70,7 @@ line-length = 88
 target-version = ['py311']
 
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -39,7 +39,7 @@ def votes_to_annotations(
     principle_index_to_text: Mapping[int, str],
     active_principles: Sequence[str],
     reference_preference: str,
-) -> Dict[str, str]:
+) -> Dict[str, Dict[str, str]]:
     """Convert principle votes to annotations in the standardized format.
 
     Args:
@@ -49,7 +49,7 @@ def votes_to_annotations(
         reference_preference: The reference preference (text_a or text_b)
 
     Returns:
-        Dictionary mapping principle IDs (hashed) to annotations
+        Dictionary mapping principle IDs (hashed) to dictionaries with preferences
     """
     annotations = {}
 
@@ -62,15 +62,15 @@ def votes_to_annotations(
 
             # Convert vote to text_a, text_b or not_applicable
             if vote is None:
-                annotations[principle_id] = "not_applicable"
+                annotations[principle_id] = {"pref": "not_applicable"}
             elif vote is True:
                 # Principle agrees with reference preference
-                annotations[principle_id] = reference_preference
+                annotations[principle_id] = {"pref": reference_preference}
             else:  # vote is False
                 # Principle disagrees with reference preference
-                annotations[principle_id] = (
-                    "text_b" if reference_preference == "text_a" else "text_a"
-                )
+                annotations[principle_id] = {
+                    "pref": "text_b" if reference_preference == "text_a" else "text_a"
+                }
 
     return annotations
 
@@ -165,7 +165,7 @@ def create_annotated_pairs(
         # Initialize annotations dict with human annotation
         annotations = {}
         reference_preference = row["preferred_text"]
-        annotations[human_annotator_id] = reference_preference
+        annotations[human_annotator_id] = {"pref": reference_preference}
 
         # Add principle annotations based on votes
         votes = comparison_votes[idx]

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -1,0 +1,241 @@
+"""Functionality for working with the annotated pairs format.
+
+This module provides tools for converting ICAI experiment results to the
+annotated pairs format, a standardized JSON format for representing model
+comparisons with annotations from both human evaluators and principles.
+"""
+
+import datetime
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence
+
+import pandas as pd
+from loguru import logger
+
+from inverse_cai.data.loader import icai
+
+# Constants
+HUMAN_ANNOTATOR_DESCRIPTION = "Human annotator from original dataset"
+FORMAT_VERSION = "1.0"
+
+
+def hash_string(s: str) -> str:
+    """Create a shortened hash of a string."""
+    return hashlib.md5(s.encode("utf-8")).hexdigest()[:8]
+
+
+def hash_comparison(text_a: str, text_b: str, prompt: Optional[str]) -> str:
+    """Create a hash ID for a comparison based on its content."""
+    combined = f"{text_a}|{text_b}|"
+    if prompt is not None:
+        combined = f"{prompt}|{combined}"
+    return hash_string(combined)
+
+
+def votes_to_annotations(
+    votes: Mapping[int, Optional[bool]],
+    principle_index_to_text: Mapping[int, str],
+    active_principles: Sequence[str],
+    reference_preference: str,
+) -> Dict[str, str]:
+    """Convert principle votes to annotations in the standardized format.
+
+    Args:
+        votes: Dictionary mapping principle IDs to their votes (True/False/None)
+        principle_index_to_text: Dictionary mapping principle IDs to their text
+        active_principles: List of active principles to include
+        reference_preference: The reference preference (text_a or text_b)
+
+    Returns:
+        Dictionary mapping principle IDs (hashed) to annotations
+    """
+    annotations = {}
+
+    for principle_idx, vote in votes.items():
+        principle_text = principle_index_to_text[principle_idx]
+
+        # Only include principles that are active
+        if principle_text in active_principles:
+            principle_id = hash_string(principle_text)
+
+            # Convert vote to text_a, text_b or not_applicable
+            if vote is None:
+                annotations[principle_id] = "not_applicable"
+            elif vote is True:
+                # Principle agrees with reference preference
+                annotations[principle_id] = reference_preference
+            else:  # vote is False
+                # Principle disagrees with reference preference
+                annotations[principle_id] = (
+                    "text_b" if reference_preference == "text_a" else "text_a"
+                )
+
+    return annotations
+
+
+def add_annotators(
+    output: Dict,
+    principles: Mapping[int, str],
+    filtered_principles: Sequence[str],
+    filter_to_constitution: bool = True,
+) -> None:
+    """Add human and principle annotators to the output structure.
+
+    This function modifies the output dictionary in-place by adding annotator
+    information to output["annotators"] and setting the default annotator.
+
+    Args:
+        output: The output dataset dictionary to modify in-place
+        principles: Dictionary of principles where keys are principle IDs
+        filtered_principles: List of filtered principles
+        filter_to_constitution: Only include principles that made it to the constitution
+    """
+    # Create human annotator
+    human_annotator_id = hash_string(HUMAN_ANNOTATOR_DESCRIPTION)
+    output["annotators"][human_annotator_id] = {
+        "name": "Human",
+        "description": HUMAN_ANNOTATOR_DESCRIPTION,
+        "type": "human",
+    }
+    output["metadata"]["default_annotator"] = human_annotator_id
+
+    # Determine active principles
+    active_principles = (
+        filtered_principles if filter_to_constitution else list(principles.values())
+    )
+
+    # Create principle annotators
+    for principle in active_principles:
+        annotator_id = hash_string(principle)
+        output["annotators"][annotator_id] = {
+            "description": principle,
+            "type": "principle",
+        }
+
+
+def create_annotated_pairs(
+    train_df: pd.DataFrame,
+    principles: Mapping[int, str],
+    filtered_principles: Sequence[str],
+    comparison_votes: Mapping[int, Dict[int, Optional[bool]]],
+    dataset_name: str,
+    filter_to_constitution: bool = True,
+) -> Dict:
+    """Convert ICAI results to annotated pairs format using direct data inputs.
+
+    Args:
+        train_df: DataFrame with training data. Must have mandatory "text_a", "text_b", and "preferred_text" rows, and an optional "input" (prompt).
+        principles: Dictionary of principles where keys are principle IDs
+        filtered_principles: List of filtered principles (those that made it to the constitution)
+        comparison_votes: Dictionary of comparison votes
+        dataset_name: Name for the dataset
+        filter_to_constitution: Only include principles that made it to the constitution
+
+    Returns:
+        The annotated pairs format as a dictionary
+    """
+    # Initialize the output structure
+    output = {
+        "metadata": {
+            "version": FORMAT_VERSION,
+            "description": "Annotated pairs dataset with annotations from ICAI",
+            "created_at": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "dataset_name": dataset_name,
+        },
+        "annotators": {},
+        "comparisons": [],
+    }
+
+    # Add annotators to the output
+    add_annotators(output, principles, filtered_principles, filter_to_constitution)
+
+    # Prepare data needed for annotations
+    human_annotator_id = output["metadata"]["default_annotator"]
+    active_principles = (
+        filtered_principles if filter_to_constitution else list(principles.values())
+    )
+
+    # Process each comparison
+    for idx, row in train_df.iterrows():
+        # Create unique ID for this comparison
+        comparison_id = hash_comparison(row["text_a"], row["text_b"], row.get("input"))
+
+        # Initialize annotations dict with human annotation
+        annotations = {}
+        reference_preference = row["preferred_text"]
+        annotations[human_annotator_id] = reference_preference
+
+        # Add principle annotations based on votes
+        votes = comparison_votes[idx]
+        principle_annotations = votes_to_annotations(
+            votes, principles, active_principles, reference_preference
+        )
+        annotations.update(principle_annotations)
+
+        # Create the comparison entry
+        comparison = {
+            "id": comparison_id,
+            "prompt": row.get("input"),
+            "text_a": row["text_a"],
+            "text_b": row["text_b"],
+            "metadata": {
+                "model_a_name": row.get("model_a"),
+                "model_b_name": row.get("model_b"),
+            },
+            "annotations": annotations,
+        }
+        output["comparisons"].append(comparison)
+
+    return output
+
+
+def results_to_annotated_pairs(
+    results_dir: str,
+    dataset_name: str,
+    filter_to_constitution: bool = True,
+) -> Dict[str, object]:
+    """Convert ICAI results to annotated pairs format from files.
+
+    Args:
+        results_dir: Path to ICAI results directory
+        dataset_name: Name for the dataset
+        filter_to_constitution: Only include principles that made it to the constitution
+
+    Returns:
+        The annotated pairs format as a dictionary
+    """
+    results_path = Path(results_dir)
+
+    # Load all required data using the icai loader module
+    train_df = icai.load_train_data(results_path)
+    principles = icai.load_principles(results_path)
+    filtered_principles = icai.load_filtered_principles(results_path)
+    comparison_votes = icai.load_votes_per_comparison(results_path)
+
+    # Call the core implementation with loaded data
+    result = create_annotated_pairs(
+        train_df=train_df,
+        principles=principles,
+        filtered_principles=filtered_principles,
+        comparison_votes=comparison_votes,
+        dataset_name=dataset_name,
+        filter_to_constitution=filter_to_constitution,
+    )
+
+    return result
+
+
+def save_annotated_pairs_to_file(annotated_pairs: Dict, output_file: str) -> None:
+    """Save the annotated pairs to a JSON file.
+
+    Args:
+        annotated_pairs: The annotated pairs dataset to save
+        output_file: Path to the output file
+    """
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(annotated_pairs, f, ensure_ascii=False, indent=2)
+    logger.info(f"Created annotated pairs format dataset: {output_file}")
+    logger.info(f"- Dataset contains {len(annotated_pairs['comparisons'])} comparisons")
+    logger.info(f"- Dataset contains {len(annotated_pairs['annotators'])} annotators")

--- a/src/inverse_cai/data/annotated_pairs_format_test.py
+++ b/src/inverse_cai/data/annotated_pairs_format_test.py
@@ -67,13 +67,13 @@ def test_votes_to_annotations():
 
     # Verify results
     assert (
-        result[honest_id] == "text_a"
+        result[honest_id]["pref"] == "text_a"
     ), "Principle with vote True should get reference_preference"
     assert (
-        result[helpful_id] == "text_b"
+        result[helpful_id]["pref"] == "text_b"
     ), "Principle with vote False should get opposite of reference_preference"
     assert (
-        result[concise_id] == "not_applicable"
+        result[concise_id]["pref"] == "not_applicable"
     ), "Principle with vote None should get not_applicable"
 
     # Test with only some active principles
@@ -90,7 +90,7 @@ def test_votes_to_annotations():
         votes, principle_index_to_text, active_principles, reference_preference
     )
     assert (
-        result[honest_id] == "text_b"
+        result[honest_id]["pref"] == "text_b"
     ), "With text_b as reference, True vote should be text_b"
 
 
@@ -202,9 +202,11 @@ def test_create_annotated_pairs():
     annotations = comparison["annotations"]
     assert human_annotator_id in annotations, "Human annotator should be in annotations"
     assert (
-        annotations[human_annotator_id] == "text_a"
+        annotations[human_annotator_id]["pref"] == "text_a"
     ), "Human annotation should match preferred_text"
 
     honest_id = hash_string("Be honest")
     assert honest_id in annotations, "Principle annotator should be in annotations"
-    assert annotations[honest_id] == "text_a", "Principle annotation should be correct"
+    assert (
+        annotations[honest_id]["pref"] == "text_a"
+    ), "Principle annotation should be correct"

--- a/src/inverse_cai/data/loader/__init__.py
+++ b/src/inverse_cai/data/loader/__init__.py
@@ -1,3 +1,4 @@
 import inverse_cai.data.loader.anthropic as anthropic
+import inverse_cai.data.loader.icai as icai
 import inverse_cai.data.loader.lmsys as lmsys
 import inverse_cai.data.loader.standard as standard

--- a/src/inverse_cai/data/loader/icai.py
+++ b/src/inverse_cai/data/loader/icai.py
@@ -1,0 +1,128 @@
+"""Functions for loading ICAI experiment results."""
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+import regex as re
+
+TRAIN_DATA_FILENAME = "000_train_data.csv"
+PRINCIPLES_FILENAME = "030_distilled_principles_per_cluster.json"
+COMPARISON_VOTES_FILENAME = "040_votes_per_comparison.csv"
+FILTERED_PRINCIPLES_FILENAME = "050_filtered_principles.json"
+
+
+def python_dict_str_to_json_compatible(dict_str: str) -> str:
+    """Convert a Python dictionary string to JSON-compatible format.
+
+    Useful for loading dictionaries that are stored as strings without having to
+    use eval.
+
+    Args:
+        dict_str: A string representation of a Python dictionary
+
+    Returns:
+        A JSON-compatible string that can be parsed with json.loads
+    """
+    # Replace Python-style booleans and None with JSON-compatible values
+    dict_str = re.sub(r"(?<=: )None", "null", dict_str)
+    dict_str = re.sub(r"(?<=: )True", "true", dict_str)
+    dict_str = re.sub(r"(?<=: )False", "false", dict_str)
+
+    # Add double quotes around keys
+    dict_str = re.sub(r"({|, )(\d+):", r'\1"\2":', dict_str)
+
+    return dict_str
+
+
+def load_train_data(results_path: Path) -> pd.DataFrame:
+    """Load training data from the results directory.
+
+    Args:
+        results_path: Path to the results directory.
+
+    Returns:
+        A pandas DataFrame containing the training data.
+    """
+    train_data_path = results_path / TRAIN_DATA_FILENAME
+    if not train_data_path.exists():
+        raise FileNotFoundError(
+            f"Could not find {TRAIN_DATA_FILENAME} in {results_path}"
+        )
+    return pd.read_csv(train_data_path)
+
+
+def load_principles(results_path: Path) -> Dict[int, str]:
+    """Load principle data from the results directory.
+
+    Args:
+        results_path: Path to the results directory.
+
+    Returns:
+        A dictionary mapping principle IDs to their corresponding principles.
+    """
+    principles = {}
+    distilled_principles_path = results_path / PRINCIPLES_FILENAME
+    if not distilled_principles_path.exists():
+        raise FileNotFoundError(
+            f"Could not find {PRINCIPLES_FILENAME} in {results_path}"
+        )
+    with open(distilled_principles_path, "r", encoding="utf-8") as f:
+        principles_dict = json.load(f)
+        # Convert keys to integers
+        principles_dict = {int(k): v for k, v in principles_dict.items()}
+        principles = principles_dict
+    return principles
+
+
+def load_votes_per_comparison(results_path: Path) -> Dict[int, Dict[int, bool]]:
+    """Load comparison votes from the results directory.
+
+    Args:
+        results_path: Path to the results directory.
+
+    Returns:
+        A dictionary mapping comparison IDs (matching the ones from the training
+        dataset) to a mapping from principle id (as returned by load_principles) to
+        a boolean indicating whether the the comparison agrees or disagrees with the
+        principle ("the comparison votes in favor of the principle"). May be
+        None, indicating that the principle is not applicable.
+    """
+    comparison_votes = {}
+    votes_per_comparison_path = results_path / COMPARISON_VOTES_FILENAME
+    if not votes_per_comparison_path.exists():
+        raise FileNotFoundError(
+            f"Could not find COMPARISON_VOTES_FILENAME in {results_path}"
+        )
+    votes_df = pd.read_csv(votes_per_comparison_path)
+    for _, row in votes_df.iterrows():
+        idx = row["index"]
+        # votes_str is a string representation of a dictionary, e.g.,
+        # "{1: True, 2: False, 3: None}"
+        votes_str = row["votes"]
+        votes_dict = json.loads(python_dict_str_to_json_compatible(votes_str))
+        comparison_votes[idx] = {int(k): v for k, v in votes_dict.items()}
+    return comparison_votes
+
+
+def load_filtered_principles(results_path: Path) -> List[str]:
+    """Load filtered principles from the results directory.
+
+    Args:
+        results_path: Path to the results directory.
+
+    Returns:
+        A list of the principles remaining after filtering. The list contains
+        strings that match a subset of the principles returned by
+        load_principles.
+    """
+    filtered_principles = []
+    filtered_principles_path = results_path / FILTERED_PRINCIPLES_FILENAME
+    if not filtered_principles_path.exists():
+        raise FileNotFoundError(
+            f"Could not find {FILTERED_PRINCIPLES_FILENAME} in {results_path}"
+        )
+    with open(filtered_principles_path, "r", encoding="utf-8") as f:
+        filtered_principles = json.load(f)
+    return filtered_principles

--- a/src/inverse_cai/data/loader/icai_test.py
+++ b/src/inverse_cai/data/loader/icai_test.py
@@ -1,0 +1,165 @@
+"""Tests for the ICAI data loader module."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from inverse_cai.data.loader.icai import (
+    load_train_data,
+    load_principles,
+    load_filtered_principles,
+    load_votes_per_comparison,
+    python_dict_str_to_json_compatible,
+)
+
+
+def test_load_train_data():
+    """Test the load_train_data function."""
+    # Create a temporary directory and file
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Create test data
+        csv_content = """index,text_a,text_b,preferred_text
+0,"In the heart of a bustling city, a sleek black cat named Shadow prowled the moonlit rooftops, her eyes gleaming with curiosity and mischief. She discovered a hidden garden atop an old apartment building, where she danced under the stars, chasing fireflies that glowed like tiny lanterns. As dawn painted the sky in hues of orange and pink, Shadow found her way back home, carrying the secret of the garden in her heart.","Across the town, in a cozy neighborhood, a golden retriever named Buddy embarked on his daily adventure, tail wagging with uncontainable excitement. He found a lost toy under the bushes in the park, its colors faded and fabric worn, but to Buddy, it was a treasure untold. Returning home with his newfound prize, Buddy's joyful barks filled the air, reminding everyone in the house that happiness can be found in the simplest of things.","text_a"
+"""
+        csv_path = tmp_path / "000_train_data.csv"
+        with open(csv_path, "w", encoding="utf-8") as f:
+            f.write(csv_content)
+
+        # Test the function
+        result = load_train_data(tmp_path)
+
+        # Verify the result has the expected structure and data
+        assert len(result) == 1, "Should have 1 row"
+        assert list(result.columns) == [
+            "index",
+            "text_a",
+            "text_b",
+            "preferred_text",
+        ], "Columns should match"
+        assert (
+            result.iloc[0]["preferred_text"] == "text_a"
+        ), "First row should prefer text_a"
+        assert (
+            "Shadow" in result.iloc[0]["text_a"]
+        ), "First row text_a should contain expected content"
+        assert (
+            "Buddy" in result.iloc[0]["text_b"]
+        ), "First row text_b should contain expected content"
+
+
+def test_load_principles():
+    """Test the load_principles function."""
+    # Create a temporary directory and file
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Create test data
+        test_json = """{
+  "1": "Prioritize responses that provide accurate and factual information",
+  "2": "Prefer responses that are helpful, informative, and directly address the user's query",
+  "3": "Favor responses that demonstrate critical thinking and nuanced understanding"
+}"""
+        json_path = tmp_path / "030_distilled_principles_per_cluster.json"
+        with open(json_path, "w", encoding="utf-8") as f:
+            f.write(test_json)
+
+        # Test the function
+        result = load_principles(tmp_path)
+
+        # Verify the result
+        expected = {
+            1: "Prioritize responses that provide accurate and factual information",
+            2: "Prefer responses that are helpful, informative, and directly address the user's query",
+            3: "Favor responses that demonstrate critical thinking and nuanced understanding",
+        }
+        assert result == expected
+
+
+def test_load_filtered_principles():
+    """Test the load_filtered_principles function."""
+    # Create a temporary directory and file
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Create test data
+        test_json = """[
+  "Prioritize responses that provide accurate and factual information",
+  "Prefer responses that are helpful, informative, and directly address the user's query"
+]"""
+        json_path = tmp_path / "050_filtered_principles.json"
+        with open(json_path, "w", encoding="utf-8") as f:
+            f.write(test_json)
+
+        # Test the function
+        result = load_filtered_principles(tmp_path)
+
+        # Verify the result
+        expected = [
+            "Prioritize responses that provide accurate and factual information",
+            "Prefer responses that are helpful, informative, and directly address the user's query",
+        ]
+        assert result == expected, "Should load the principles list correctly"
+
+
+def test_load_comparison_votes():
+    """Test the load_comparison_votes function."""
+    # For this test, we need to create a CSV file with properly formatted vote data
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Create test data
+        csv_content = """index,votes
+0,"{0: True, 1: False, 2: None}"
+1,"{0: True, 1: None, 2: None}"
+"""
+        csv_path = tmp_path / "040_votes_per_comparison.csv"
+        with open(csv_path, "w", encoding="utf-8") as f:
+            f.write(csv_content)
+
+        # Test the function
+        result = load_votes_per_comparison(tmp_path)
+
+        # Verify the result structure
+        assert 0 in result, "Index 0 should be in the result"
+        assert 1 in result, "Index 1 should be in the result"
+
+        # Verify the votes for index 0
+        assert 1 in result[0], "Principle 1 should be in votes for index 0"
+        assert result[0][0] is True
+        assert result[0][1] is False
+        assert result[0][2] is None
+        assert result[1][0] is True
+        assert result[1][1] is None
+        assert result[1][2] is None
+
+
+def test_python_dict_str_to_json_compatible():
+    """Test the python_dict_str_to_json_compatible utility function."""
+    # Test basic conversion of Python values to JSON
+    python_str = "{1: True, 2: False, 3: None}"
+    json_str = python_dict_str_to_json_compatible(python_str)
+
+    # Verify conversion
+    assert '"1"' in json_str, "Keys should be quoted"
+    assert '"2"' in json_str, "Keys should be quoted"
+    assert '"3"' in json_str, "Keys should be quoted"
+    assert "true" in json_str, "True should be converted to true"
+    assert "false" in json_str, "False should be converted to false"
+    assert "null" in json_str, "None should be converted to null"
+
+    # Test that the result can be parsed by json.loads
+    result = json.loads(json_str)
+    assert result == {"1": True, "2": False, "3": None}
+
+    # Test with more complex dictionary
+    complex_str = "{1: True, 20: False, 300: None, 4000: True}"
+    json_str = python_dict_str_to_json_compatible(complex_str)
+
+    # Verify all keys are properly quoted
+    result = json.loads(json_str)
+    assert result == {"1": True, "20": False, "300": None, "4000": True}

--- a/src/inverse_cai/experiment/core.py
+++ b/src/inverse_cai/experiment/core.py
@@ -17,7 +17,10 @@ import langchain.globals
 import inverse_cai
 from inverse_cai.experiment.config.main import ExpConfig
 import inverse_cai.annotators
-
+from inverse_cai.data.annotated_pairs_format import (
+    results_to_annotated_pairs,
+    save_annotated_pairs_to_file,
+)
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=ExpConfig)
@@ -293,6 +296,15 @@ def run(cfg: DictConfig):
         "recommend to manually inspect ICAI's interpretable constitutions before using "
         "them for downstream tasks to avoid accidentally amplifying harmful biases."
     )
+
+    # Generate annotated pairs format
+    ap_output_file = results_path / "070_annotated_pairs_dataset.json"
+    annotated_pairs = results_to_annotated_pairs(
+        results_dir=str(results_path),
+        dataset_name=f"ICAI Dataset - {pathlib.Path(hydra_out_path).name}",
+    )
+    save_annotated_pairs_to_file(annotated_pairs, str(ap_output_file))
+    logger.info(f"Generated annotated pairs format at {ap_output_file}")
 
     logger.info(f"Experiment finished. Find results at {results_path}")
     logger.info(

--- a/tools/convert_to_annotated_pairs.py
+++ b/tools/convert_to_annotated_pairs.py
@@ -24,12 +24,8 @@ def main():
     parser = argparse.ArgumentParser(
         description="Convert ICAI results to annotated pairs format."
     )
-    parser.add_argument(
-        "results_dir", help="Path to ICAI results directory"
-    )
-    parser.add_argument(
-        "output", help="Path to output annotated pairs JSON"
-    )
+    parser.add_argument("results_dir", help="Path to ICAI results directory")
+    parser.add_argument("output", help="Path to output annotated pairs JSON")
     parser.add_argument(
         "--dataset-name",
         "-n",
@@ -53,7 +49,9 @@ def main():
             filter_to_constitution=not args.include_all_principles,
         )
         save_annotated_pairs_to_file(annotated_pairs, args.output)
-        logger.success(f"Successfully saved {len(annotated_pairs['comparisons'])} pairs to {args.output}")
+        logger.success(
+            f"Successfully saved {len(annotated_pairs['comparisons'])} pairs to {args.output}"
+        )
     except Exception as e:
         logger.error(f"Error during conversion: {e}")
         return 1

--- a/tools/convert_to_annotated_pairs.py
+++ b/tools/convert_to_annotated_pairs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Generate an annotated pairs dataset from legacy ICAI results. Note that a recent version of ICAI
+natively generates this format.
+
+Usage:
+  # Generate annotated pairs format from ICAI results directory
+  python convert_to_annotated_pairs.py path/to/results ap_dataset.json
+"""
+
+import argparse
+import sys
+
+from loguru import logger
+
+from inverse_cai.data.annotated_pairs_format import (
+    results_to_annotated_pairs,
+    save_annotated_pairs_to_file,
+)
+
+
+def main():
+    """Main function to parse arguments and run the converter."""
+    parser = argparse.ArgumentParser(
+        description="Convert ICAI results to annotated pairs format."
+    )
+    parser.add_argument(
+        "results_dir", help="Path to ICAI results directory"
+    )
+    parser.add_argument(
+        "output", help="Path to output annotated pairs JSON"
+    )
+    parser.add_argument(
+        "--dataset-name",
+        "-n",
+        default="ICAI Generated Dataset",
+        help="Name for the dataset (default: ICAI Generated Dataset)",
+    )
+    parser.add_argument(
+        "--include-all-principles",
+        "-a",
+        action="store_true",
+        help="Include all principles, not just those in the constitution",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        logger.info(f"Converting ICAI results from {args.results_dir}")
+        annotated_pairs = results_to_annotated_pairs(
+            results_dir=args.results_dir,
+            dataset_name=args.dataset_name,
+            filter_to_constitution=not args.include_all_principles,
+        )
+        save_annotated_pairs_to_file(annotated_pairs, args.output)
+        logger.success(f"Successfully saved {len(annotated_pairs['comparisons'])} pairs to {args.output}")
+    except Exception as e:
+        logger.error(f"Error during conversion: {e}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/convert_to_annotated_pairs.py
+++ b/tools/convert_to_annotated_pairs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Generate an annotated pairs dataset from legacy ICAI results. Note that a recent version of ICAI
-natively generates this format.
+Generate an annotated pairs dataset from legacy ICAI results (version <= 0.2.1). Note that more recent 
+versions of ICAI natively generate this format.
 
 Usage:
   # Generate annotated pairs format from ICAI results directory


### PR DESCRIPTION
As discussed out of band.

- Adds a `annotated_pairs_format` module for converting ICAI experiment results to a consistent JSON format.
- Integrates automatic annotated pairs generation into the experiment pipeline.
- Provides a CLI tool to convert existing experiment results to the new format.