### PR TITLE
v0.3.1

### DIFF
--- a/exp/configs/310_allenai_multipref/config.yaml
+++ b/exp/configs/310_allenai_multipref/config.yaml
@@ -1,0 +1,9 @@
+data_path: "./data/processed/allenai/multipref_gpt4_human_merged.csv"
+data_start_index: 0
+data_len: 10000
+alg_model: "openai/gpt-4o-mini-2024-07-18"
+s0_skip_principle_generation: true
+s0_added_standard_principles_to_test:
+  - v2
+annotator:
+  skip: true

--- a/notebooks/81_allenai_multipref_parsing.ipynb
+++ b/notebooks/81_allenai_multipref_parsing.ipynb
@@ -344,11 +344,11 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 20,
+            "execution_count": 18,
             "metadata": {},
             "outputs": [],
             "source": [
-                "merged_df.to_csv(\"../data/processed/allenai/multipref_gpt4_human_merged.csv\", index=True, index_label=\"index\")\n"
+                "merged_df[:10000].to_csv(\"../data/processed/allenai/multipref_gpt4_human_merged.csv\", index=True, index_label=\"index\")\n"
             ]
         },
         {

--- a/notebooks/81_allenai_multipref_parsing.ipynb
+++ b/notebooks/81_allenai_multipref_parsing.ipynb
@@ -1,0 +1,392 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# OLMo Model Dataset Parsing\n",
+                "\n",
+                "This notebook loads and processes the OLMo dataset from Hugging Face for use with the ICAI framework."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Install any missing packages\n",
+                "# !pip install datasets transformers pandas numpy matplotlib"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Import necessary libraries\n",
+                "import os\n",
+                "import pandas as pd\n",
+                "import numpy as np\n",
+                "import matplotlib.pyplot as plt\n",
+                "from datasets import load_dataset\n",
+                "from tqdm.auto import tqdm"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Load the Multipref Dataset from Hugging Face\n",
+                "\n",
+                "The Allen Institute for AI (AI2) released the OLMo model along with several datasets. Let's load the main dataset from Hugging Face."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Load the OLMo dataset from Hugging Face\n",
+                "# You can choose a specific config/subset if needed\n",
+                "dataset = load_dataset(\"allenai/multipref\")\n",
+                "ds_gpt4 = load_dataset(\"allenai/multipref\", \"gpt4_overall_binarized\")\n",
+                "ds_human = load_dataset(\"allenai/multipref\", \"human_overall_binarized\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "main_df = dataset[\"train\"].to_pandas()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "main_df.to_csv(\"../data/processed/allenai/multipref_original.csv\", index=False)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Get all unique values for overall_pref from the normal_worker_annotations\n",
+                "overall_prefs = []\n",
+                "for annotations in main_df[\"normal_worker_annotations\"]:\n",
+                "    for annotation in annotations:\n",
+                "        if 'overall_pref' in annotation:\n",
+                "            overall_prefs.append(annotation['overall_pref'])\n",
+                "\n",
+                "# Display unique values and their counts\n",
+                "unique_prefs = pd.Series(overall_prefs).value_counts()\n",
+                "print(\"Unique overall_pref values:\")\n",
+                "print(unique_prefs)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "pref_series = pd.Series(overall_prefs)\n",
+                "num_a_better = (pref_series == \"A-is-slightly-better\").sum() + (pref_series == \"A-is-clearly-better\").sum()\n",
+                "num_b_better = (pref_series == \"B-is-slightly-better\").sum() + (pref_series == \"B-is-clearly-better\").sum()\n",
+                "num_tie = (pref_series == \"Tie\").sum()\n",
+                "\n",
+                "print(f\"Number of A-is-better: {num_a_better}\")\n",
+                "print(f\"Number of B-is-better: {num_b_better}\")\n",
+                "print(f\"Number of Tie: {num_tie}\")\n",
+                "\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# model distribution\n",
+                "\n",
+                "model_a_counts = main_df[\"model_a\"].value_counts()\n",
+                "model_b_counts = main_df[\"model_b\"].value_counts()\n",
+                "\n",
+                "print(f\"Model A counts: {model_a_counts}\")\n",
+                "print(f\"\\n\\nModel B counts: {model_b_counts}\")\n",
+                "\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Create a function to flatten annotations and add them as columns to the main dataframe\n",
+                "def flatten_annotations(df, annotation_column, prefix):\n",
+                "    # Create a copy of the dataframe\n",
+                "    result_df = df.copy()\n",
+                "\n",
+                "    # Get the maximum number of annotations in any row\n",
+                "    max_annotations = max(len(annotations) for annotations in df[annotation_column])\n",
+                "\n",
+                "    # For each row in the dataframe\n",
+                "    for idx, row in tqdm(df.iterrows(), total=len(df), desc=f\"Flattening {prefix} annotations\"):\n",
+                "        annotations = row[annotation_column]\n",
+                "\n",
+                "        # For each annotation in the list\n",
+                "        for i, annotation in enumerate(annotations):\n",
+                "            # Add each field as a new column with a prefix indicating the annotation source and index\n",
+                "            for key, value in annotation.items():\n",
+                "                column_name = f\"{prefix}_{i}_{key}\"\n",
+                "\n",
+                "                # Handle special case for arrays like 'helpful_checked_reasons'\n",
+                "                if isinstance(value, np.ndarray):\n",
+                "                    # Convert array to a comma-separated string\n",
+                "                    value_str = ','.join(value) if len(value) > 0 else ''\n",
+                "                    result_df.at[idx, column_name] = value_str\n",
+                "\n",
+                "                    # Also create individual boolean columns for each reason in the array\n",
+                "                    for reason in value:\n",
+                "                        reason_column = f\"{prefix}_{i}_{key}_{reason}\"\n",
+                "                        result_df.at[idx, reason_column] = True\n",
+                "                else:\n",
+                "                    # For regular values, just add them directly\n",
+                "                    result_df.at[idx, column_name] = value\n",
+                "\n",
+                "    return result_df\n",
+                "\n",
+                "# Flatten normal worker annotations\n",
+                "main_df_with_normal = flatten_annotations(main_df, \"normal_worker_annotations\", \"normal\")\n",
+                "\n",
+                "# Flatten expert worker annotations\n",
+                "main_df_flattened = flatten_annotations(main_df_with_normal, \"expert_worker_annotations\", \"expert\")\n",
+                "\n",
+                "# Display the number of columns before and after flattening\n",
+                "print(f\"\\nOriginal number of columns: {len(main_df.columns)}\")\n",
+                "print(f\"Number of columns after flattening: {len(main_df_flattened.columns)}\")\n",
+                "\n",
+                "# Display some of the new columns\n",
+                "new_columns = [col for col in main_df_flattened.columns if col not in main_df.columns]\n",
+                "print(f\"\\nNumber of new columns added: {len(new_columns)}\")\n",
+                "print(\"\\nSample of new columns:\")\n",
+                "print(new_columns[:20])\n",
+                "\n",
+                "main_df_flattened = main_df_flattened.sort_index(axis=1)\n",
+                "\n",
+                "# Example of what an annotation looks like (for reference)\n",
+                "# example_evaluator = {'evaluator': 'keen_williams',\n",
+                "#  'harmless_checked_reasons': np.array([], dtype=object),\n",
+                "#  'harmless_confidence': 'absolutely-confident',\n",
+                "#  'harmless_own_reason': '',\n",
+                "#  'harmless_pref': 'Tie',\n",
+                "#  'helpful_checked_reasons': np.array(['well_formatted', 'coherent', 'creative', 'better_tone'],\n",
+                "#        dtype=object),\n",
+                "#  'helpful_confidence': 'absolutely-confident',\n",
+                "#  'helpful_own_reason': '',\n",
+                "#  'helpful_pref': 'B-is-clearly-better',\n",
+                "#  'overall_confidence': 'absolutely-confident',\n",
+                "#  'overall_pref': 'B-is-clearly-better',\n",
+                "#  'time_spent': 213,\n",
+                "#  'timestamp': '2024-05-03 04:17:06.661562',\n",
+                "#  'truthful_checked_reasons': np.array([], dtype=object),\n",
+                "#  'truthful_confidence': 'absolutely-confident',\n",
+                "#  'truthful_own_reason': '',\n",
+                "#  'truthful_pref': 'Tie'}"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# merge\n",
+                "\n",
+                "df_gpt4 = ds_gpt4[\"train\"].to_pandas()\n",
+                "df_human = ds_human[\"train\"].to_pandas()\n",
+                "\n",
+                "# add suffixes to columns\n",
+                "df_gpt4 = df_gpt4.add_suffix(\"_gpt4\")\n",
+                "df_human = df_human.add_suffix(\"_human\")\n",
+                "\n",
+                "\n",
+                "merged_df = pd.merge(main_df_flattened, df_gpt4, left_on=\"comparison_id\", right_on=\"comparison_id_gpt4\", how=\"left\")\n",
+                "merged_df = pd.merge(merged_df, df_human, left_on=\"comparison_id\", right_on=\"comparison_id_human\", how=\"left\")\n",
+                "\n",
+                "\n",
+                "for dataset in [ds_gpt4, ds_human]:\n",
+                "    for idx, row in merged_df.iterrows():\n",
+                "        for chat_col in [\"gpt4\", \"human\"]:\n",
+                "            selected_completion = row[f\"chosen_{chat_col}\"][-1][\"content\"]\n",
+                "            if selected_completion == row[\"completion_a\"]:\n",
+                "                merged_df.at[idx, f\"preferred_text_{chat_col}\"] = \"text_a\"\n",
+                "            elif selected_completion == row[\"completion_b\"]:\n",
+                "                merged_df.at[idx, f\"preferred_text_{chat_col}\"] = \"text_b\"\n",
+                "            else:\n",
+                "                print(f\"Selected completion {selected_completion} not in {row['completion_a']} or {row['completion_b']}\")\n",
+                "                merged_df.at[idx, f\"preferred_text_{chat_col}\"] = \"invalid\"\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "merged_df"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# create text_a and text_b columns from \"text\" and \"completion_a\" and \"completion_b\"\n",
+                "# e.g. text_a = [{'role': 'user', 'content': text}, {'role': 'assistant', 'content': completion_a}]\n",
+                "\n",
+                "merged_df[\"text_a\"] = merged_df[[\"text\", \"completion_a\"]].apply(lambda x: [{'role': 'user', 'content': x[\"text\"]}, {'role': 'assistant', 'content': x[\"completion_a\"]}], axis=1)\n",
+                "merged_df[\"text_b\"] = merged_df[[\"text\", \"completion_b\"]].apply(lambda x: [{'role': 'user', 'content': x[\"text\"]}, {'role': 'assistant', 'content': x[\"completion_b\"]}], axis=1)\n",
+                "\n",
+                "\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "print(merged_df[\"text_a\"][0])\n",
+                "print(merged_df[\"text_b\"][0])\n",
+                "print(merged_df[\"chosen_gpt4\"][0])\n",
+                "print(merged_df[\"chosen_human\"][0])\n",
+                "print(merged_df[\"preferred_text_gpt4\"][0])\n",
+                "print(merged_df[\"preferred_text_human\"][0])"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "list(merged_df.columns)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Convert normal and expert overall preferences into \"text_a\", \"text_b\" or \"tie\"\n",
+                "# First, check if these columns exist in the dataframe\n",
+                "normal_pref_cols = [col for col in merged_df.columns if 'normal_' in col and '_overall_pref' in col]\n",
+                "expert_pref_cols = [col for col in merged_df.columns if 'expert_' in col and '_overall_pref' in col]\n",
+                "\n",
+                "# Function to convert preference notation to text_a/text_b/tie\n",
+                "def convert_pref_to_text(pref):\n",
+                "    if pref == 'A-is-slightly-better' or pref == 'A-is-clearly-better':\n",
+                "        return 'text_a'\n",
+                "    elif pref == 'B-is-slightly-better' or pref == 'B-is-clearly-better':\n",
+                "        return 'text_b'\n",
+                "    elif pref == 'Tie':\n",
+                "        return 'tie'\n",
+                "    else:\n",
+                "        return 'invalid'\n",
+                "\n",
+                "# Process normal annotator preferences\n",
+                "for col in normal_pref_cols:\n",
+                "    new_col = col.replace('_overall_pref', '_preferred_text')\n",
+                "    merged_df[new_col] = merged_df[col].apply(convert_pref_to_text)\n",
+                "\n",
+                "# Process expert annotator preferences\n",
+                "for col in expert_pref_cols:\n",
+                "    new_col = col.replace('_overall_pref', '_preferred_text')\n",
+                "    merged_df[new_col] = merged_df[col].apply(convert_pref_to_text)\n",
+                "\n",
+                "print(f\"Converted {len(normal_pref_cols)} normal annotator preferences and {len(expert_pref_cols)} expert annotator preferences\")\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 16,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# remove \"prompt_human\" and \"prompt_gpt4\" columns\n",
+                "# remove \"rejected_gpt4\" and \"rejected_human\" columns\n",
+                "# remove \"chosen_gpt4\" and \"chosen_human\" columns\n",
+                "\n",
+                "merged_df = merged_df.drop(columns=[\"prompt_human\", \"prompt_gpt4\", \"rejected_gpt4\", \"rejected_human\", \"chosen_gpt4\", \"chosen_human\"])"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 17,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "merged_df[\"preferred_text\"] = merged_df[\"preferred_text_human\"]"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 20,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "merged_df.to_csv(\"../data/processed/allenai/multipref_gpt4_human_merged.csv\", index=True, index_label=\"index\")\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "merged_df.iloc[0].to_dict()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.13.1"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inverse-cai"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
   { name="rdnfn", email="hi@arduin.io" },
   { name="timokau", email="" },
@@ -70,7 +70,7 @@ line-length = 88
 target-version = ['py311']
 
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.3.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inverse-cai"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="rdnfn", email="hi@arduin.io" },
   { name="timokau", email="" },
@@ -70,7 +70,7 @@ line-length = 88
 target-version = ['py311']
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -244,7 +244,7 @@ def create_annotated_pairs(
 
     # Add metadata columns to the overall metadata
     if metadata_columns:
-        output["metadata"]["available_metadata_columns"] = metadata_columns
+        output["metadata"]["available_metadata_keys_per_comparison"] = metadata_columns
         logger.info(f"Available metadata columns: {metadata_columns}")
 
     # Prepare data needed for annotations

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -285,7 +285,9 @@ def create_annotated_pairs(
                     column_annotator_id = hash_string(f"column_{col}")
 
                     # Add the annotation
-                    annotations[column_annotator_id] = {"value": str(row[col])}
+                    annotations[column_annotator_id] = {
+                        DEFAULT_PREFERENCE_KEY: str(row[col])
+                    }
 
         # Create the comparison entry
         comparison = {

--- a/src/inverse_cai/data/annotated_pairs_format_test.py
+++ b/src/inverse_cai/data/annotated_pairs_format_test.py
@@ -13,6 +13,9 @@ from inverse_cai.data.annotated_pairs_format import (
     votes_to_annotations,
     add_annotators,
     create_annotated_pairs,
+    HUMAN_ANNOTATOR_DESCRIPTION,
+    DEFAULT_ANNOTATOR_TYPE,
+    DEFAULT_PREFERENCE_COLUMN,
 )
 
 
@@ -108,12 +111,12 @@ def test_add_annotators():
     assert len(output["annotators"]) == 2, "Should have human + 1 principle annotator"
 
     # Compute expected human annotator ID
-    human_annotator_id = hash_string("Human annotator from original dataset")
+    human_annotator_id = hash_string(HUMAN_ANNOTATOR_DESCRIPTION)
     assert (
         human_annotator_id in output["annotators"]
     ), "Human annotator should be in output"
     assert (
-        output["annotators"][human_annotator_id]["type"] == "human"
+        output["annotators"][human_annotator_id]["type"] == DEFAULT_ANNOTATOR_TYPE
     ), "Human type should be set"
     assert (
         output["metadata"]["default_annotator"] == human_annotator_id
@@ -146,6 +149,29 @@ def test_add_annotators():
     assert honest_id in output["annotators"], "First principle should be in output"
     assert helpful_id in output["annotators"], "Second principle should be in output"
 
+    # Test with additional columns
+    output = {"annotators": {}, "metadata": {}}
+    additional_columns = ["column1", "column2"]
+    add_annotators(
+        output,
+        principles,
+        filtered_principles,
+        filter_to_constitution=True,
+        additional_columns=additional_columns,
+    )
+
+    # Verify column annotators were added
+    column1_id = hash_string("column_column1")
+    column2_id = hash_string("column_column2")
+    assert column1_id in output["annotators"], "Column1 annotator should be in output"
+    assert column2_id in output["annotators"], "Column2 annotator should be in output"
+    assert (
+        output["annotators"][column1_id]["type"] == "column"
+    ), "Column type should be set"
+    assert (
+        output["annotators"][column2_id]["type"] == "column"
+    ), "Column type should be set"
+
 
 def test_create_annotated_pairs():
     """Test the create_annotated_pairs function."""
@@ -155,7 +181,7 @@ def test_create_annotated_pairs():
             "text_a": ["Response A"],
             "text_b": ["Response B"],
             "input": ["What is the capital of France?"],
-            "preferred_text": ["text_a"],
+            DEFAULT_PREFERENCE_COLUMN: ["text_a"],
             "model_a": ["Model X"],
             "model_b": ["Model Y"],
         }
@@ -210,3 +236,80 @@ def test_create_annotated_pairs():
     assert (
         annotations[honest_id]["pref"] == "text_a"
     ), "Principle annotation should be correct"
+
+
+def test_create_annotated_pairs_with_additional_columns():
+    """Test the create_annotated_pairs function with additional columns."""
+    # Setup test data
+    train_df = pd.DataFrame(
+        {
+            "text_a": ["Response A"],
+            "text_b": ["Response B"],
+            "input": ["What is the capital of France?"],
+            DEFAULT_PREFERENCE_COLUMN: ["text_a"],
+            "model_a": ["Model X"],
+            "model_b": ["Model Y"],
+            "additional_column": ["Some value"],
+        }
+    )
+
+    principles = {1: "Be honest", 2: "Be helpful"}
+    filtered_principles = ["Be honest"]
+    comparison_votes = {0: {1: True, 2: False}}
+    dataset_name = "Test Dataset"
+    additional_columns = ["additional_column"]
+
+    # Run function
+    result = create_annotated_pairs(
+        train_df,
+        principles,
+        filtered_principles,
+        comparison_votes,
+        dataset_name,
+        additional_columns=additional_columns,
+    )
+
+    # Verify the structure
+    assert "metadata" in result, "Result should have metadata"
+    assert "annotators" in result, "Result should have annotators"
+    assert "comparisons" in result, "Result should have comparisons"
+
+    # Verify metadata
+    assert (
+        result["metadata"]["dataset_name"] == dataset_name
+    ), "Dataset name should be set"
+    assert result["metadata"]["version"] == "1.0", "Version should be set"
+
+    # Verify annotators
+    human_annotator_id = None
+    column_annotator_id = None
+    for annotator_id, annotator in result["annotators"].items():
+        if annotator["type"] == "human":
+            human_annotator_id = annotator_id
+        elif annotator["type"] == "column":
+            column_annotator_id = annotator_id
+    assert human_annotator_id is not None, "Should have a human annotator"
+    assert column_annotator_id is not None, "Should have a column annotator"
+
+    # Verify comparison
+    assert len(result["comparisons"]) == 1, "Should have 1 comparison"
+    comparison = result["comparisons"][0]
+    assert comparison["text_a"] == "Response A", "text_a should be set"
+    assert comparison["text_b"] == "Response B", "text_b should be set"
+    assert (
+        comparison["prompt"] == "What is the capital of France?"
+    ), "prompt should be set"
+
+    # Verify annotations
+    annotations = comparison["annotations"]
+    assert human_annotator_id in annotations, "Human annotator should be in annotations"
+    assert (
+        annotations[human_annotator_id]["pref"] == "text_a"
+    ), "Human annotation should match preferred_text"
+
+    assert (
+        column_annotator_id in annotations
+    ), "Column annotator should be in annotations"
+    assert (
+        annotations[column_annotator_id]["value"] == "Some value"
+    ), "Column annotation should match the value in the dataframe"

--- a/src/inverse_cai/data/annotated_pairs_format_test.py
+++ b/src/inverse_cai/data/annotated_pairs_format_test.py
@@ -315,7 +315,7 @@ def test_create_annotated_pairs_with_additional_columns():
     ), "Default annotator should be in annotations"
     assert (
         annotations[default_annotator_id]["pref"] == "text_a"
-    ), f"Default annotation should match preferred_text ({DEFAULT_PREFERENCE_COLUMN}, {annotations[default_annotator_id]['pref']} != text_a)"
+    ), "Default annotation should match preferred_text"
 
     assert (
         unknown_annotator_id in annotations

--- a/src/inverse_cai/data/annotated_pairs_format_test.py
+++ b/src/inverse_cai/data/annotated_pairs_format_test.py
@@ -288,7 +288,7 @@ def test_create_annotated_pairs_with_additional_columns():
     default_annotator_id = None
     unknown_annotator_id = None
     for annotator_id, annotator in result["annotators"].items():
-        if annotator["type"] == DEFAULT_ANNOTATOR_TYPE:
+        if annotator["description"] == DEFAULT_ANNOTATOR_DESCRIPTION:
             default_annotator_id = annotator_id
         if annotator["type"] == "unknown":
             unknown_annotator_id = annotator_id
@@ -315,11 +315,8 @@ def test_create_annotated_pairs_with_additional_columns():
     ), "Default annotator should be in annotations"
     assert (
         annotations[default_annotator_id]["pref"] == "text_a"
-    ), "Default annotation should match preferred_text"
+    ), f"Default annotation should match preferred_text ({DEFAULT_PREFERENCE_COLUMN}, {annotations[default_annotator_id]['pref']} != text_a)"
 
     assert (
-        column_annotator_id in annotations
-    ), "Column annotator should be in annotations"
-    assert (
-        annotations[column_annotator_id]["value"] == "Some value"
-    ), "Column annotation should match the value in the dataframe"
+        unknown_annotator_id in annotations
+    ), "Unknown annotator should be in annotations"

--- a/src/inverse_cai/paper_plotting.py
+++ b/src/inverse_cai/paper_plotting.py
@@ -45,8 +45,14 @@ def get_results_from_paths(
             constitution = None
 
         df = pd.read_csv(path)
-        df["annotator"] = df["Unnamed: 0"]
-        df = df.drop(columns=["Unnamed: 0"])
+
+        # make adaptable to old and new results files
+        if "annotator" not in df.columns:
+            df["annotator"] = df["Unnamed: 0"]
+            df = df.drop(columns=["Unnamed: 0"])
+
+        if "Human agreement" not in df.columns:
+            df.rename(columns={"agreement": "Human agreement"}, inplace=True)
 
         # for annotators with "constitution" in their name, add the constitution
         if constitution:

--- a/tools/convert_to_annotated_pairs.py
+++ b/tools/convert_to_annotated_pairs.py
@@ -39,6 +39,13 @@ def main():
         default=False,
         help="Only include principles from the constitution (default: include all principles)",
     )
+    parser.add_argument(
+        "--additional-columns",
+        "-a",
+        nargs="+",
+        default=[],
+        help="Additional columns from the training data to include as annotations (default: none, example: -a 'column1 column2')",
+    )
 
     args = parser.parse_args()
 
@@ -48,6 +55,7 @@ def main():
             results_dir=args.results_dir,
             dataset_name=args.dataset_name,
             filter_to_constitution=args.only_include_constitution_principles,
+            additional_columns=args.additional_columns,
         )
         save_annotated_pairs_to_file(annotated_pairs, args.output)
         logger.success(

--- a/tools/convert_to_annotated_pairs.py
+++ b/tools/convert_to_annotated_pairs.py
@@ -46,6 +46,12 @@ def main():
         default=[],
         help="Additional columns from the training data to include as annotations (default: none, example: -a 'column1 column2')",
     )
+    parser.add_argument(
+        "--no-auto-detect",
+        action="store_true",
+        default=False,
+        help="Disable automatic detection of annotator columns (default: auto detection is enabled)",
+    )
 
     args = parser.parse_args()
 
@@ -56,6 +62,7 @@ def main():
             dataset_name=args.dataset_name,
             filter_to_constitution=args.only_include_constitution_principles,
             additional_columns=args.additional_columns,
+            auto_detect_annotators=not args.no_auto_detect,
         )
         save_annotated_pairs_to_file(annotated_pairs, args.output)
         logger.success(


### PR DESCRIPTION
Minor updates, primarily to the annotated pairs format.

- Make the default annotator column (preferred text) description and name agnostic of whether human or not (may be AI-generated or by design sometimes)
- Add support for additional annotator columns in original data
  - Including automatically detecting likely annotator columns (by checking for presence of "text_a" and "text_b")
- Multipref parsing notebook
- Changed default of conversion tool from including only constitutional principles to all principles (+ automatically detected additional annotator columns)
