### PR TITLE
Fix prompt principles, miscellaneous other improvements (see commit messages)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "hydra-core",
   "matplotlib",
   "setuptools", # for alpaca-eval
+  "backoff",
 ]
 
 [project.optional-dependencies]

--- a/src/inverse_cai/algorithm/clustering.py
+++ b/src/inverse_cai/algorithm/clustering.py
@@ -3,7 +3,6 @@ import copy
 from sklearn.cluster import KMeans
 from loguru import logger
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_openai import OpenAIEmbeddings
 
 import inverse_cai.models
 from inverse_cai.experiment.config import ExpConfig
@@ -13,6 +12,7 @@ import inverse_cai.algorithm.utils
 def cluster_principles(
     principles: list,
     num_clusters: int,
+    model_name: str,
     random_clusters: bool,
 ):
     """
@@ -29,7 +29,7 @@ def cluster_principles(
         )
         return {i: [principle] for i, principle in enumerate(set(principles))}
     else:
-        return cluster_principles_with_embedding(principles, num_clusters)
+        return cluster_principles_with_embedding(principles, num_clusters, model_name)
 
 
 def cluster_principles_random(
@@ -56,6 +56,7 @@ def cluster_principles_random(
 def cluster_principles_with_embedding(
     principles: list,
     num_clusters: int,
+    model_name: str,
 ):
     """
     Cluster principles.
@@ -63,7 +64,7 @@ def cluster_principles_with_embedding(
 
     # generating embedding for each principle
     logger.info("Generating embeddings for principles")
-    embeddings_model = OpenAIEmbeddings()
+    embeddings_model = inverse_cai.models.get_embeddings_model(model_name)
     embeddings = embeddings_model.embed_documents(principles)
     logger.info("Embeddings generated")
 

--- a/src/inverse_cai/algorithm/clustering.py
+++ b/src/inverse_cai/algorithm/clustering.py
@@ -103,7 +103,7 @@ def get_cluster_summaries(
     model_name,
     sample_instead_of_rewrite,
     config: ExpConfig,
-    prompt_principles: bool = False,
+    is_prompt_principles: bool = False,
 ):
     """
     Get summaries for each cluster.
@@ -122,7 +122,7 @@ def get_cluster_summaries(
                 principles,
                 model_name=model_name,
                 config=config,
-                prompt_principles=prompt_principles,
+                is_prompt_principles=is_prompt_principles,
             )
     return summaries
 
@@ -131,7 +131,7 @@ def summarize_cluster(
     single_cluster_principles,
     model_name,
     config: ExpConfig,
-    prompt_principles: bool = False,
+    is_prompt_principles: bool = False,
 ):
     """
     Given a cluster of principles, summarize the cluster.
@@ -140,7 +140,7 @@ def summarize_cluster(
     messages = inverse_cai.algorithm.utils.parse_prompt(
         prompt_str=(
             config.alg_prompts.prompt_cluster_summary_prompt
-            if prompt_principles
+            if is_prompt_principles
             else config.alg_prompts.cluster_summary_prompt
         ),
         prompt_kwargs=dict(

--- a/src/inverse_cai/algorithm/main.py
+++ b/src/inverse_cai/algorithm/main.py
@@ -108,6 +108,7 @@ def run(
         clusters = cluster_principles(
             principles,
             num_clusters=num_clusters,
+            model_name=model_name,
             random_clusters=random_clusters,
         )
         save_to_json(clusters, save_path / "020_principle_clusters.json")
@@ -123,6 +124,7 @@ def run(
         prompt_clusters = cluster_principles(
             prompt_principles,
             num_clusters=num_clusters,
+            model_name=model_name,
             random_clusters=random_clusters,
         )
         save_to_json(prompt_clusters, save_path / "025_prompt_principle_clusters.json")
@@ -263,6 +265,7 @@ def run(
             filtered_clusters = cluster_principles(
                 filtered_principles,
                 num_clusters=max_principles,
+                model_name=model_name,
                 random_clusters=False,
             )
 

--- a/src/inverse_cai/algorithm/main.py
+++ b/src/inverse_cai/algorithm/main.py
@@ -77,7 +77,7 @@ def run(
     if not config.s0_skip_principle_generation:
         ### STAGE 1: Generate principles from feedback
         logger.info("Stage 1: Generate principles from feedback")
-        feedback, principles, prompt_principles = generate_principles_from_feedback(
+        feedback, principles, is_prompt_principles = generate_principles_from_feedback(
             feedback=feedback,
             num_principles_per_sampling_step=num_principles_per_sampling_step,
             model_name=model_name,
@@ -99,9 +99,9 @@ def run(
         print("Principles:")
         print("\n".join(principles))
         print("Prompt Principles:")
-        print("\n".join(prompt_principles))
+        print("\n".join(is_prompt_principles))
         save_to_json(principles, save_path / "011_principles_list.json")
-        save_to_json(prompt_principles, save_path / "016_prompt_principles_list.json")
+        save_to_json(is_prompt_principles, save_path / "016_prompt_principles_list.json")
 
         ### STAGE 2: Cluster principles
         logger.info("Stage 2: Cluster principles")
@@ -122,7 +122,7 @@ def run(
         print_clusters(clusters, summaries)
 
         prompt_clusters = cluster_principles(
-            prompt_principles,
+            is_prompt_principles,
             num_clusters=num_clusters,
             model_name=model_name,
             random_clusters=random_clusters,
@@ -134,7 +134,7 @@ def run(
             model_name=model_name,
             sample_instead_of_rewrite=config.s2_sample_cluster_instead_of_rewrite,
             config=config,
-            prompt_principles=True,
+            is_prompt_principles=True,
         )
         print_clusters(prompt_clusters, prompt_summaries)
     else:
@@ -207,7 +207,7 @@ def run(
             model_name=model_name,
             cache_path=None,
             config=config,
-            prompt_principles=True,
+            is_prompt_principles=True,
             max_concurrent_tasks=config.async_task_num,
             num_seeds=config.s3_num_seeds_to_reannotate_with,
             voting_method_cross_seed=config.s3_voting_method_cross_seed,

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -35,8 +35,10 @@ def generate_principles_from_feedback(
     Returns:
         A list of principles.
     """
+    num_samples = config.s1_num_samples_for_principle_generation or len(feedback)
+
     logger.info("Generating principles from feedback")
-    logger.info(f"Number of rankings: {len(feedback)}")
+    logger.info(f"Number of rankings: {num_samples}")
     logger.info(
         "Number of different prompt templates used for generation: "
         f"{len(config.alg_prompts.generator_prompts)}"
@@ -48,7 +50,7 @@ def generate_principles_from_feedback(
         f"Number of principles per sampling step per prompt: {num_principles_per_sampling_step}"
     )
     overall_num_principles = (
-        -(len(feedback) // -num_rankings_per_sampling_step)  # ceiling division
+        -(num_samples // -num_rankings_per_sampling_step)  # ceiling division
         * len(config.alg_prompts.generator_prompts)
         * num_principles_per_sampling_step
     )
@@ -96,7 +98,7 @@ def generate_principles_from_feedback(
                 process_row(
                     index, row, num_principles_per_sampling_step, model_name, config
                 )
-                for index, row in feedback.iterrows()
+                for index, row in feedback.sample(num_samples).iterrows()
             ]
 
             # execute all tasks concurrently

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -174,7 +174,7 @@ async def generate_principles_from_single_ranking(
         )
 
         # generate principles
-        principle_output = (await model.ainvoke(messages)).content
+        principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
 
         # parse the principles
         try:
@@ -205,7 +205,7 @@ async def generate_principles_from_single_ranking(
         )
 
         # generate principles
-        principle_output = (await model.ainvoke(messages)).content
+        principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
 
         # parse the principles
         try:

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -84,6 +84,7 @@ def generate_principles_from_feedback(
                 async with semaphore:
                     principles, prompt_principles = (
                         await generate_principles_from_single_ranking(
+                            prompt=inverse_cai.algorithm.utils.get_prompt_from_row(row),
                             preferred_text=get_preferred_text(row),
                             rejected_text=get_rejected_text(row),
                             num_principles=num_principles_per_sampling_step,
@@ -137,6 +138,7 @@ def generate_principles_from_feedback(
 
 
 async def generate_principles_from_single_ranking(
+    prompt: str,
     preferred_text: str,
     rejected_text: str,
     num_principles,
@@ -160,68 +162,55 @@ async def generate_principles_from_single_ranking(
 
     # get the model
     model = inverse_cai.models.get_model(model_name)
-    principles: list = []
-    prompt_principles: list = []
+    principless: list = []
 
-    for prompt in config.alg_prompts.generator_prompts:
-        messages = inverse_cai.algorithm.utils.parse_prompt(
-            prompt_str=prompt,
-            prompt_kwargs=dict(
-                preferred_sample=preferred_text,
-                rejected_sample=rejected_text,
-                num_principles=num_principles,
-            ),
-        )
+    for generator, kwargs, optional_kwargs in [ (
+        config.alg_prompts.generator_prompts,
+        dict(
+            preferred_sample=preferred_text,
+            rejected_sample=rejected_text,
+            num_principles=num_principles,
+        ),
+        dict()
+    ), (
+        config.alg_prompts.prompt_generator_prompts,
+        dict(
+            prompt=prompt,
+            num_principles=num_principles,
+        ),
+        dict(
+            preferred_sample=preferred_text,
+            rejected_sample=rejected_text,
+        ),
+    )]:
+        principles = []
+        for prompt in generator:
+            messages = inverse_cai.algorithm.utils.parse_prompt(
+                prompt_str=prompt,
+                prompt_kwargs=kwargs,
+                prompt_optional_kwargs=optional_kwargs,
+            )
 
-        # generate principles
-        principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
+            # generate principles
+            principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
 
-        # parse the principles
-        try:
-            principle_output = clean_principle_str(principle_output)
-            parsed_output = ast.literal_eval(principle_output)["principles"]
-            principles += parsed_output
-            if len(parsed_output) < num_principles:
-                logger.warning(
-                    f"Generated fewer ({len(parsed_output)}) principles "
-                    f"than expected ({num_principles})"
-                )
-        except Exception as e:
-            logger.error(f"Failed to parse principles: {principle_output}")
-            logger.error(e)
+            # parse the principles
+            try:
+                principle_output = clean_principle_str(principle_output)
+                parsed_output = ast.literal_eval(principle_output)
+                principles.extend(parsed_output.get("features") or parsed_output["principles"])
+                if len(principles) != num_principles:
+                    logger.warning(
+                        f"Generated a different number ({len(parsed_output)}) "
+                        f"of principles than expected ({num_principles})"
+                    )
+            except Exception as e:
+                logger.error(f"Failed to parse principles: {principle_output}")
+                logger.error(e)
 
-    for prompt in config.alg_prompts.prompt_generator_prompts:
-        messages = inverse_cai.algorithm.utils.parse_prompt(
-            prompt_str=prompt,
-            prompt_kwargs=dict(
-                preferred_sample=preferred_text,
-                rejected_sample=rejected_text,
-                prompt=inverse_cai.algorithm.utils.get_prompt_from_two_samples(
-                    sample_a=preferred_text,
-                    sample_b=rejected_text,
-                ),
-                num_principles=num_principles,
-            ),
-        )
+        principless.append(principles)
 
-        # generate principles
-        principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
-
-        # parse the principles
-        try:
-            principle_output = clean_principle_str(principle_output)
-            parsed_output = ast.literal_eval(principle_output)["features"]
-            prompt_principles += parsed_output
-            if len(parsed_output) < num_principles:
-                logger.warning(
-                    f"Generated fewer ({len(parsed_output)}) principles "
-                    f"than expected ({num_principles})"
-                )
-        except Exception as e:
-            logger.error(f"Failed to parse principles: {principle_output}")
-            logger.error(e)
-
-    return principles, prompt_principles
+    return tuple(principless)
 
 
 def clean_principle_str(principle_str: str) -> str:

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -192,7 +192,11 @@ async def generate_principles_from_single_ranking(
             )
 
             # generate principles
-            principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
+            try:
+                principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
+            except Exception as e:
+                logger.error(f"Failed to generate principles")
+                logger.error(e)
 
             # parse the principles
             try:

--- a/src/inverse_cai/algorithm/utils.py
+++ b/src/inverse_cai/algorithm/utils.py
@@ -20,6 +20,13 @@ def parse_prompt(prompt_str: str, prompt_kwargs, prompt_optional_kwargs) -> list
     # It's ok if optional kwargs aren't present in the prompt
     prompt_kwargs |= prompt_optional_kwargs
 
+    # check prompt_str keys are in kwargs and log warnings for invalid keys
+    for m in re.finditer(r'{([^{} ]+)}', prompt_str):
+        key = m.group(1)
+        if key not in prompt_kwargs:
+            logger.error(f"Key '{key}' is not a valid key. Check your prompts.")
+            prompt_str = prompt_str.replace(f"{{{key}}}", "")
+
     messages = alpaca_eval.utils.prompt_to_chatml(prompt_str)
 
     # add values to individual messages AFTER prompt to chatml

--- a/src/inverse_cai/algorithm/utils.py
+++ b/src/inverse_cai/algorithm/utils.py
@@ -1,7 +1,12 @@
 import shutil
 from pathlib import Path
 from loguru import logger
+from typing import Awaitable
+import openai
 import alpaca_eval.utils
+import backoff
+import logging
+import re
 
 
 def parse_prompt(prompt_str: str, prompt_kwargs) -> list[dict]:
@@ -63,3 +68,58 @@ def copy_cache(source_results_path: Path, target_results_path: Path):
         source_results_path / "cache", target_results_path / "cache", dirs_exist_ok=True
     )
     logger.info(f"Copied over prior cache from '{source_results_path}'")
+
+
+# These errors seem to come from multiple parts of the stack, and
+# probably differ depending on the provider, etc, so this is awkward...
+def _get_http_code(err):
+    if isinstance(err, openai.APIStatusError):
+        return err.status_code
+
+    if len(err.args) > 0 and isinstance(err.args[0], dict) and "code" in err.args[0]:
+        return err.args[0]["code"]
+
+    try:
+        return int(re.sub(r".*Error code: (\d*).*", r"\1", str(err)))
+    except ValueError:
+        return None
+
+
+def _get_error_message(err):
+    if isinstance(err, openai.APIStatusError) and isinstance(err.body, dict) and "message" in err.body:
+        return err.body["message"]
+
+    if len(err.args) > 0 and isinstance(err.args[0], dict) and "message" in err.args[0]:
+        return err.args[0]["messag"]
+
+    return str(error)
+
+
+def _fatal_model_error(err):
+    code = _get_http_code(err)
+    if code: print(f"Got HTTP error {code}") # debug
+
+    if code in (403,):
+        # OpenAI returns this when it moderates
+        logger.warning(f'403 Forbidden: {_get_error_message(err)}')
+        return False
+    elif code in (408, 420, 429, 444, 498, 499):
+        # 4xx client errors
+        # see https://http.cat/<code>
+        # some of these are very obscure, but include all retryable ones just in case
+        return False
+    elif code // 100 == 5:
+        # 5xx server errors
+        return False
+    else:
+        return True
+
+
+@backoff.on_exception(
+    backoff.expo,
+    Exception,
+    max_tries=10,
+    giveup=_fatal_model_error,
+)
+async def run_with_http_retries(fn, *args, **kwargs):
+    return await fn(*args, **kwargs)

--- a/src/inverse_cai/algorithm/voting.py
+++ b/src/inverse_cai/algorithm/voting.py
@@ -419,7 +419,7 @@ async def get_preference_vote_for_single_text(
     vote = parse_individual_pref_vote(vote, num_principles=len(principles))
 
     # change back to original keys
-    vote = {numbered_principles[k]: v for k, v in vote.items()}
+    vote = {numbered_principles[k]: v for k, v in vote.items() if k in numbered_principles}
 
     if flipped:
         vote = {k: "A" if v == "B" else "B" if v == "A" else v for k, v in vote.items()}

--- a/src/inverse_cai/algorithm/voting.py
+++ b/src/inverse_cai/algorithm/voting.py
@@ -45,7 +45,7 @@ def get_votes_for_principles(
 
     logger.info("Getting votes for principles")
     if prompt_principles:
-        logger.info("Voting for prompt principles (rather than regular principles)")
+        logger.info("Voting for prompt principles")
     else:
         logger.info("Voting for regular principles")
 
@@ -327,23 +327,7 @@ async def get_prompt_principle_vote_for_single_text(
     )
 
     model = inverse_cai.models.get_model(model_name)
-
-    sleep_time = 1  # simple exponential backoff
-    while True:
-        try:
-            vote = (await model.ainvoke(messages)).content
-            break
-        except Exception as e:
-            if "Error code: 429" in str(e):
-                logger.warning(f"Ratelimit error invoking model: {e}")
-                logger.warning(f"Sleeping for {sleep_time}s and trying again...")
-                await asyncio.sleep(sleep_time)
-                sleep_time *= 2
-            else:
-                logger.error(f"Error invoking model: {e}")
-                logger.error(f"Parsed messages: {messages}")
-                raise e
-
+    vote = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
     vote = parse_individual_pref_vote(
         vote, num_principles=len(summaries), prompt_principles=True
     )
@@ -399,23 +383,7 @@ async def get_preference_vote_for_single_text(
     )
 
     model = inverse_cai.models.get_model(model_name)
-
-    sleep_time = 1  # simple exponential backoff
-    while True:
-        try:
-            vote = (await model.ainvoke(messages)).content
-            break
-        except Exception as e:
-            if "Error code: 429" in str(e):
-                logger.warning(f"Ratelimit error invoking model: {e}")
-                logger.warning(f"Sleeping for {sleep_time}s and trying again...")
-                await asyncio.sleep(sleep_time)
-                sleep_time *= 2
-            else:
-                logger.error(f"Error invoking model: {e}")
-                logger.error(f"Parsed messages: {messages}")
-                raise e
-
+    vote = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
     vote = parse_individual_pref_vote(vote, num_principles=len(principles))
 
     # change back to original keys

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -133,6 +133,7 @@ def votes_to_annotations(
 def add_annotators(
     output: Dict,
     principles: Mapping[int, str] | None = None,
+    principle_type: str = "principle",
     additional_columns: List[str] = None,
 ) -> None:
     """Add all annotators to the output structure.
@@ -165,7 +166,7 @@ def add_annotators(
         annotator_id = hash_string(principle)
         output["annotators"][annotator_id] = {
             "description": principle,
-            "type": "principle",
+            "type": principle_type,
         }
 
     # Create column annotators if additional columns are specified
@@ -277,12 +278,14 @@ def create_annotated_pairs(
     add_annotators(
         output,
         principles,
+        "preference_principle",
         all_additional_columns,
     )
 
     add_annotators(
         output,
         non_preference_principles,
+        "non_preference_principle",
         all_additional_columns,
     )
 

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -235,6 +235,7 @@ def create_annotated_pairs(
     ) = None,
     additional_columns: List[str] = None,
     auto_detect_annotators: bool = True,
+    ignored_columns: tuple = ("principles", "prompt_principles")
 ) -> Dict:
     """Convert ICAI results to annotated pairs format using direct data inputs.
 
@@ -301,7 +302,11 @@ def create_annotated_pairs(
     metadata_columns = [
         col
         for col in df.columns
-        if col not in standard_columns and col not in all_additional_columns
+        if (
+            col not in standard_columns and
+            col not in all_additional_columns and
+            col not in ignored_columns
+        )
     ]
 
     # Add metadata columns to the overall metadata

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -132,8 +132,8 @@ def votes_to_annotations(
 
 def add_annotators(
     output: Dict,
+    principle_type: str,
     principles: Mapping[int, str] | None = None,
-    principle_type: str = "principle",
     additional_columns: List[str] = None,
 ) -> None:
     """Add all annotators to the output structure.
@@ -278,15 +278,15 @@ def create_annotated_pairs(
     # Add all annotators to the output
     add_annotators(
         output,
-        principles,
         "preference_principle",
+        principles,
         all_additional_columns,
     )
 
     add_annotators(
         output,
-        non_preference_principles,
         "non_preference_principle",
+        non_preference_principles,
         all_additional_columns,
     )
 

--- a/src/inverse_cai/experiment/config/main.py
+++ b/src/inverse_cai/experiment/config/main.py
@@ -183,6 +183,7 @@ class ExpConfig:
     s0_skip_principle_generation: bool = False
 
     # Stage 1: principle generation
+    s1_num_samples_for_principle_generation: int | None = None
     s1_num_principles_per_sampling_step: int = 3
     s1_num_principles_per_instance: int | None = None
     s1_num_rankings_per_sampling_step: int = 1

--- a/src/inverse_cai/experiment/config/main.py
+++ b/src/inverse_cai/experiment/config/main.py
@@ -183,7 +183,9 @@ class ExpConfig:
     s0_skip_principle_generation: bool = False
 
     # Stage 1: principle generation
-    s1_num_samples_for_principle_generation: int | None = None
+    s1_num_samples_for_principle_generation: int | None = (
+        None  # how many of the training samples to use for generating principles (defaults to all)
+    )
     s1_num_principles_per_sampling_step: int = 3
     s1_num_principles_per_instance: int | None = None
     s1_num_rankings_per_sampling_step: int = 1

--- a/src/inverse_cai/experiment/config/prompts.py
+++ b/src/inverse_cai/experiment/config/prompts.py
@@ -154,7 +154,7 @@ class PromptConfig:
     prompt_generator_prompts: list[str] = field(
         default_factory=lambda: [
             # DEFAULT_PROMPT_GENERATOR_PROMPT_V1,
-            # DEFAULT_PROMPT_GENERATOR_PROMPT_V2,
+            DEFAULT_PROMPT_GENERATOR_PROMPT_V2,
         ]
     )
     voting_prompt: str = DEFAULT_VOTING_PROMPT

--- a/src/inverse_cai/experiment/core.py
+++ b/src/inverse_cai/experiment/core.py
@@ -350,7 +350,7 @@ def run(cfg: DictConfig):
                 model_name=cfg.alg_model,
                 cache_path=test_annotation_cache_path,
                 config=cfg,
-                prompt_principles=True,
+                is_prompt_principles=True,
                 max_concurrent_tasks=cfg.async_task_num,
                 num_seeds=cfg.s3_num_seeds_to_reannotate_with,
                 voting_method_cross_seed=cfg.s3_voting_method_cross_seed,


### PR DESCRIPTION
The prompt principle code is much neater now :) (still could probably be even better, I kinda think the "right" thing to do is for each principle to be sent around as a dict including some metadata rather than just a string, and then needing this ugly `prompt_principles` bool in every function...)

One breaking change: in the annotated pairs format, type is now set to "preference_principle" for ordinary principles and "non_preference_principle" for prompt principles. This allows them to be better separated in downstream code. (The names are slightly more generic than "response"/"prompt" principles, one can hypothesize principles which aren't clearly "prompt" or "response", but should still be classified as "preference" or "non_preference"...)

I probably definitely broke all the tests :)