### PR TITLE
Upgrade cache

### DIFF
--- a/src/inverse_cai/algorithm/clustering.py
+++ b/src/inverse_cai/algorithm/clustering.py
@@ -150,7 +150,7 @@ def summarize_cluster(
         ),
     )
 
-    model = inverse_cai.models.get_model(model_name)
+    model = inverse_cai.models.get_model(model_name, cache_seed=config.random_seed)
 
     summary = model.invoke(messages).content
     return summary

--- a/src/inverse_cai/algorithm/clustering.py
+++ b/src/inverse_cai/algorithm/clustering.py
@@ -1,5 +1,6 @@
 import random
 import copy
+import numpy as np
 from sklearn.cluster import KMeans
 from loguru import logger
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -117,7 +118,7 @@ def get_cluster_summaries(
         if len(principles) == 1:
             summaries[i] = principles[0]
         elif sample_instead_of_rewrite:
-            summaries[i] = random.choice(principles)
+            summaries[i] = np.random.choice(principles)
         else:
             summaries[i] = summarize_cluster(
                 principles,

--- a/src/inverse_cai/algorithm/clustering.py
+++ b/src/inverse_cai/algorithm/clustering.py
@@ -42,8 +42,9 @@ def cluster_principles_random(
     logger.info(f"Clustering principles randomly into {num_clusters} clusters")
     principles = copy.deepcopy(principles)
     principles_by_cluster = {}
-    # shuffle the principles
-    random.shuffle(principles)
+
+    # random seed has already been set
+    np.random.shuffle(principles)
     for i, principle in enumerate(principles):
         cluster = i % num_clusters
         if cluster not in principles_by_cluster:

--- a/src/inverse_cai/algorithm/main.py
+++ b/src/inverse_cai/algorithm/main.py
@@ -2,6 +2,7 @@ from loguru import logger
 import pandas as pd
 import random
 import shutil
+import numpy as np
 from pathlib import Path
 
 from inverse_cai.algorithm.clustering import (

--- a/src/inverse_cai/algorithm/main.py
+++ b/src/inverse_cai/algorithm/main.py
@@ -309,7 +309,9 @@ def run(
 
         # randomly sample from all principles instead of voting
         available_principles = list(summaries.values())
-        final_principles = random.choices(available_principles, k=max_principles)
+
+        # random seed has already been set
+        final_principles = np.random.choice(available_principles, size=max_principles)
 
     # Generate constitution text from principles
     constitution = "\n".join(

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -193,10 +193,12 @@ async def generate_principles_from_single_ranking(
 
             # generate principles
             try:
+                # TODO: HTTP failures are now cached. There needs to be a way to invalidate the cache!
                 principle_output = (await inverse_cai.algorithm.utils.run_with_http_retries(model.ainvoke, messages)).content
             except Exception as e:
                 logger.error(f"Failed to generate principles")
                 logger.error(e)
+                continue
 
             # parse the principles
             try:

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -1,6 +1,7 @@
 import ast
 import asyncio
 import pandas as pd
+import traceback
 from tqdm.asyncio import tqdm
 from loguru import logger
 
@@ -160,6 +161,9 @@ async def generate_principles_from_single_ranking(
     """
     assert num_principles > 0, "Number of principles must be greater than 0"
 
+    # NOTE: this function can't contain randomness because it might be run
+    # out of order. If it does need to, a seed must be carefully passed in.
+
     # get the model
     model = inverse_cai.models.get_model(model_name)
     principless: list = []
@@ -198,6 +202,7 @@ async def generate_principles_from_single_ranking(
             except Exception as e:
                 logger.error(f"Failed to generate principles")
                 logger.error(e)
+                logger.info(traceback.format_exc())
                 continue
 
             # parse the principles
@@ -213,6 +218,8 @@ async def generate_principles_from_single_ranking(
             except Exception as e:
                 logger.error(f"Failed to parse principles: {principle_output}")
                 logger.error(e)
+                logger.info(traceback.format_exc())
+                continue
 
         principless.append(principles)
 

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -166,7 +166,7 @@ async def generate_principles_from_single_ranking(
     # out of order. If it does need to, a seed must be carefully passed in.
 
     # get the model
-    model = inverse_cai.models.get_model(model_name)
+    model = inverse_cai.models.get_model(model_name, cache_seed=config.random_seed)
     principless: list = []
 
     runners = [

--- a/src/inverse_cai/algorithm/utils.py
+++ b/src/inverse_cai/algorithm/utils.py
@@ -1,11 +1,9 @@
 import shutil
 from pathlib import Path
 from loguru import logger
-from typing import Awaitable
 import openai
 import alpaca_eval.utils
 import backoff
-import logging
 import re
 
 

--- a/src/inverse_cai/algorithm/voting.py
+++ b/src/inverse_cai/algorithm/voting.py
@@ -2,6 +2,7 @@ import ast
 import asyncio
 import random
 import time
+import json
 import numpy as np
 import pandas as pd
 from pathlib import Path
@@ -60,11 +61,11 @@ def get_votes_for_principles(
         f"Running up to {max_concurrent_tasks} LLM calls asynchronously at the same time."
     )
 
-    hashed_votes_per_seed = {seed: [] for seed in range(1, num_seeds + 1)}
+    hashed_votes_per_seed = {seed: [] for seed in range(num_seeds)}
 
-    for seed in range(1, num_seeds + 1):
+    for seed in range(num_seeds):
         # Shuffle summary keys and split into chunks
-        summary_keys = list(summaries.keys())
+        summary_keys = sorted(list(summaries.keys()))
         np.random.shuffle(summary_keys)
         summaries_parts = [
             {k: summaries[k] for k in summary_keys[i : i + max_votes_in_single_prompt]}
@@ -76,7 +77,7 @@ def get_votes_for_principles(
             f"Full summaries: {summaries}\nFull summaries parts: {summaries_parts}"
             f"max votes in single prompt: {max_votes_in_single_prompt}"
         )
-        logger.info(f"Running voting for seed {seed}/{num_seeds}.")
+        logger.info(f"Running voting for seed {seed+1}/{num_seeds}.")
         for i, summary_part in enumerate(summaries_parts):
             logger.info(f"Starting pass {i+1}/{len(summaries_parts)}")
             cache_path_seed = Path(f"{cache_path}_seed_{seed}")
@@ -89,6 +90,7 @@ def get_votes_for_principles(
                     cache_path=cache_path_seed,
                     prompt_principles=prompt_principles,
                     max_concurrent_tasks=max_concurrent_tasks,
+                    seed=seed,
                 )
             )
             hashed_votes_per_seed[seed].append(votes)
@@ -194,6 +196,7 @@ async def run_pass_to_get_votes_for_principles(
     cache_path: Path,
     prompt_principles: bool,
     max_concurrent_tasks: int = 10,
+    seed: int = 0,
 ) -> dict:
     """
     Given a dataframe of conversations, run voting with each proposed
@@ -210,7 +213,7 @@ async def run_pass_to_get_votes_for_principles(
 
     # Function to process each row
     async def process_row(
-        index, row, summaries, model_name, config, initial_cached_votes
+        index, row, summaries, model_name, config, initial_cached_votes, function_seed,
     ):
         async with semaphore:
             preferred = get_preferred_text(row)
@@ -245,6 +248,8 @@ async def run_pass_to_get_votes_for_principles(
                 model_name=model_name,
                 config=config,
                 prompt_principles=prompt_principles,
+                function_seed=function_seed,
+                model_seed=config.random_seed + seed,
             )
 
             # Update cache
@@ -259,7 +264,8 @@ async def run_pass_to_get_votes_for_principles(
 
     # Create async tasks for parallel processing
     tasks = [
-        process_row(index, row, summaries, model_name, config, initial_cached_votes)
+        # these functions will run out of order, so we pass in a deterministic seed for repeatability
+        process_row(index, row, summaries, model_name, config, initial_cached_votes, np.random.randint(0, 2**32))
         for index, row in feedback_df.iterrows()
     ]
 
@@ -281,6 +287,8 @@ async def get_preference_vote_for_single_text(
     config: ExpConfig,
     model_name: str,
     prompt_principles: bool = False,
+    function_seed = 0,
+    model_seed = 0,
 ):
     """
     Given a dataframe of conversations, let the model votes according to each proposed principles.
@@ -291,8 +299,8 @@ async def get_preference_vote_for_single_text(
     votes can be corrected for right away.
     """
 
-    # random seed has already been set
-    flipped = np.random.choice([True, False])
+    rng = np.random.default_rng(function_seed)
+    flipped = rng.choice([True, False])
 
     if flipped:
         sample_a, sample_b = rejected_sample, preferred_sample
@@ -314,7 +322,7 @@ async def get_preference_vote_for_single_text(
         prompt_optional_kwargs={},
     )
 
-    model = inverse_cai.models.get_model(model_name)
+    model = inverse_cai.models.get_model(model_name, seed=model_seed)
 
     vote = None
     try:

--- a/src/inverse_cai/algorithm/voting.py
+++ b/src/inverse_cai/algorithm/voting.py
@@ -301,7 +301,7 @@ async def get_preference_vote_for_messages(
     valid_values: dict,
     model_seed: int = 0,
 ):
-    model = inverse_cai.models.get_model(model_name, seed=model_seed)
+    model = inverse_cai.models.get_model(model_name, cache_seed=model_seed)
 
     vote = None
     try:

--- a/src/inverse_cai/algorithm/voting.py
+++ b/src/inverse_cai/algorithm/voting.py
@@ -2,6 +2,7 @@ import ast
 import asyncio
 import random
 import time
+import numpy as np
 import pandas as pd
 from pathlib import Path
 from loguru import logger
@@ -64,8 +65,7 @@ def get_votes_for_principles(
     for seed in range(1, num_seeds + 1):
         # Shuffle summary keys and split into chunks
         summary_keys = list(summaries.keys())
-        random.seed(seed)
-        random.shuffle(summary_keys)
+        np.random.shuffle(summary_keys)
         summaries_parts = [
             {k: summaries[k] for k in summary_keys[i : i + max_votes_in_single_prompt]}
             for i in range(0, len(summary_keys), max_votes_in_single_prompt)
@@ -291,7 +291,8 @@ async def get_preference_vote_for_single_text(
     votes can be corrected for right away.
     """
 
-    flipped = random.choice([True, False])
+    # random seed has already been set
+    flipped = np.random.choice([True, False])
 
     if flipped:
         sample_a, sample_b = rejected_sample, preferred_sample

--- a/src/inverse_cai/algorithm/voting.py
+++ b/src/inverse_cai/algorithm/voting.py
@@ -213,7 +213,13 @@ async def run_pass_to_get_votes_for_principles(
 
     # Function to process each row
     async def process_row(
-        index, row, summaries, model_name, config, initial_cached_votes, function_seed,
+        index,
+        row,
+        summaries,
+        model_name,
+        config,
+        initial_cached_votes,
+        function_seed,
     ):
         async with semaphore:
             preferred = get_preferred_text(row)
@@ -265,7 +271,15 @@ async def run_pass_to_get_votes_for_principles(
     # Create async tasks for parallel processing
     tasks = [
         # these functions will run out of order, so we pass in a deterministic seed for repeatability
-        process_row(index, row, summaries, model_name, config, initial_cached_votes, np.random.randint(0, 2**32))
+        process_row(
+            index,
+            row,
+            summaries,
+            model_name,
+            config,
+            initial_cached_votes,
+            np.random.randint(0, 2**32),
+        )
         for index, row in feedback_df.iterrows()
     ]
 
@@ -343,8 +357,8 @@ async def get_prompt_preference_vote_for_single_text(
     principles,
     config: ExpConfig,
     model_name: str,
-    function_seed = 0,
-    model_seed = 0,
+    function_seed=0,
+    model_seed=0,
 ):
     numbered_principles = {i: v for i, v in enumerate(principles)}
 
@@ -377,8 +391,8 @@ async def get_response_preference_vote_for_single_text(
     principles,
     config: ExpConfig,
     model_name: str,
-    function_seed = 0,
-    model_seed = 0,
+    function_seed=0,
+    model_seed=0,
 ):
     rng = np.random.default_rng(function_seed)
     flipped = rng.choice([True, False])

--- a/src/inverse_cai/experiment/config/main.py
+++ b/src/inverse_cai/experiment/config/main.py
@@ -149,6 +149,8 @@ class ExpConfig:
         True  # Whether to merge the prompts and texts, if available
     )
 
+    random_seed: int = 0
+
     # Test data config
     test_data_path: Any = None
     test_data_len: Any = None

--- a/src/inverse_cai/experiment/core.py
+++ b/src/inverse_cai/experiment/core.py
@@ -212,7 +212,6 @@ def run(cfg: DictConfig):
         langchain.globals.set_llm_cache(
             langchain.cache.SQLiteCache(database_path=".langchain.db")
         )
-        np.random.seed(123)
 
     # Handle OpenRouter flag
     if cfg.alg_use_openrouter:
@@ -232,6 +231,9 @@ def run(cfg: DictConfig):
             "but also `generate_constitution` is set to True. "
             "Please only set one of them."
         )
+
+    # set random seed
+    np.random.seed(cfg.random_seed)
 
     # load secrets
     dotenv.load_dotenv(cfg.secrets_path, verbose=True)

--- a/src/inverse_cai/models.py
+++ b/src/inverse_cai/models.py
@@ -1,7 +1,6 @@
 from typing import Any, Sequence, Mapping, Union
 from functools import partial
 import json
-from frozendict import frozendict
 from filelock import FileLock
 
 import asyncio
@@ -38,7 +37,7 @@ def serializable(obj):
     elif isinstance(obj, Sequence):
         return tuple(serializable(x) for x in obj)
     elif isinstance(obj, Mapping):
-        return frozendict({k: serializable(v) for k, v in obj.items()})
+        return {k: serializable(v) for k, v in obj.items()}
     elif isinstance(obj, langchain_core.messages.base.BaseMessage):
         return serializable(langchain_core.messages.base.message_to_dict(obj))
     else:

--- a/src/inverse_cai/models.py
+++ b/src/inverse_cai/models.py
@@ -227,6 +227,7 @@ class CachedEmbeddingsModel(CachedModel):
         # TODO: support other embeddings?
 
         super().__init__(cache_dir=f"exp/cache/models/{name}", **kwargs)
+        self.cached_sync_funcs = ("embed_documents",)
 
         openrouter = name.startswith("openrouter")
         openai_api_key = os.environ.get("OPENAI_API_KEY")

--- a/src/inverse_cai/models.py
+++ b/src/inverse_cai/models.py
@@ -32,9 +32,7 @@ OPENROUTER_HEADERS = {
 
 
 def serializable(obj):
-    if obj is None:
-        return None
-    elif isinstance(obj, Union[str, int, float, bool]):
+    if isinstance(obj, Union[str, int, float, bool, type(None)]):
         return obj
     elif isinstance(obj, Sequence):
         return tuple(serializable(x) for x in obj)

--- a/src/inverse_cai/models.py
+++ b/src/inverse_cai/models.py
@@ -42,7 +42,9 @@ def serializable(obj):
     elif isinstance(obj, langchain_core.messages.base.BaseMessage):
         return serializable(langchain_core.messages.base.message_to_dict(obj))
     else:
-        logger.warning(f"{obj} ({type(obj).__name__}) is not serializable, converting to string for cache key")
+        logger.warning(
+            f"{obj} ({type(obj).__name__}) is not serializable, converting to string for cache key"
+        )
         return str(obj)
 
 
@@ -151,7 +153,6 @@ class CachedLLM(CachedModel):
         max_tokens: int = 1000,
         **kwargs,
     ) -> Any:
-
         """Get a language model instance.
 
         Args:
@@ -163,7 +164,10 @@ class CachedLLM(CachedModel):
         Returns:
             CachedModel-wrapped LogWrapper-wrapped language model instance
         """
-        super().__init__(cache_dir=f"exp/cache/models/{name}_{temp}_{enable_logprobs}_{max_tokens}", **kwargs)
+        super().__init__(
+            cache_dir=f"exp/cache/models/{name}_{temp}_{enable_logprobs}_{max_tokens}",
+            **kwargs,
+        )
         self.cached_sync_funcs = ("invoke",)
         self.cached_async_funcs = ("ainvoke",)
 
@@ -243,6 +247,7 @@ class CachedEmbeddingsModel(CachedModel):
 # compatibility
 def get_model(*args, **kwargs):
     return CachedLLM(*args, **kwargs)
+
 
 def get_embeddings_model(*args, **kwargs):
     return CachedEmbeddingsModel(*args, **kwargs)

--- a/src/inverse_cai/models.py
+++ b/src/inverse_cai/models.py
@@ -32,7 +32,9 @@ OPENROUTER_HEADERS = {
 
 
 def serializable(obj):
-    if isinstance(obj, Union[str, int, float]):
+    if obj is None:
+        return None
+    elif isinstance(obj, Union[str, int, float, bool]):
         return obj
     elif isinstance(obj, Sequence):
         return tuple(serializable(x) for x in obj)
@@ -66,7 +68,7 @@ def partial_hash(obj):
     elif isinstance(obj, Sequence):
         return tuple(partial_hash(x) for x in obj)
     elif isinstance(obj, Mapping):
-        return frozendict({k: partial_hash(v) for k, v in obj.items()})
+        return {k: partial_hash(v) for k, v in obj.items()}
     else:
         return f"hash:{hash_obj(obj)[:8]}"
 
@@ -118,7 +120,7 @@ class CachedModel:
 
         if result is None:
             logger.debug(f"cache {self.seed} miss ({h[:8]})")
-            result = self.model.__getattr__(func)(*args, **kwargs)
+            result = getattr(self.model, func)(*args, **kwargs)
 
             if asyncio.iscoroutine(result):
                 result = await result

--- a/src/inverse_cai/models.py
+++ b/src/inverse_cai/models.py
@@ -1,7 +1,14 @@
-from typing import Any
+from typing import Any, Hashable, Sequence, Mapping
+from functools import partial
 import json
+from frozendict import frozendict
+
+import asyncio
+import langchain_core.messages.base
 import numpy as np
+import pickle
 import os
+import os.path
 
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_anthropic import ChatAnthropic
@@ -23,86 +30,183 @@ OPENROUTER_HEADERS = {
 }
 
 
-def get_model(
-    name: str,
-    temp: float = 0.0,
-    enable_logprobs: bool = False,
-    max_tokens: int = 1000,
-) -> Any:
-    """Get a language model instance.
-
-    Args:
-        name: Model name with provider prefix (e.g. "openai/gpt-4o-2024-05-13")
-        temp: Temperature for generation (default: 0.0)
-        enable_logprobs: Whether to enable logprobs for token probabilities (default: False)
-        max_tokens: Maximum tokens to generate (default: 1000)
-
-    Returns:
-        LogWrapper-wrapped language model instance
-    """
-    if enable_logprobs:
-        model_kwargs = {"logprobs": True, "top_logprobs": 10}
+def hashable(obj):
+    if isinstance(obj, str):
+        # Strings are sequences, and all their subelements are also sequences, on and on forever
+        return obj
+    if isinstance(obj, Sequence):
+        return tuple(hashable(x) for x in obj)
+    elif isinstance(obj, Mapping):
+        return frozendict({k: hashable(v) for k, v in obj.items()})
+    elif isinstance(obj, langchain_core.messages.base.BaseMessage):
+        return hashable(langchain_core.messages.base.message_to_dict(obj))
+    elif isinstance(obj, Hashable):
+        return obj
     else:
-        model_kwargs = {}
+        logger.warning(f"{obj} ({type(obj).__name__}) is not hashable, converting to string for cache key")
+        return str(obj)
 
-    if name.startswith("openai"):
-        return ChatOpenAI(
-            model=name.split("/")[1],
-            max_tokens=max_tokens,
-            temperature=temp,
-            model_kwargs=model_kwargs,
-        )
 
-    if name.startswith("anthropic"):
-        return ChatAnthropic(
-            model=name.split("/")[1],
-            max_tokens=max_tokens,
-            temperature=temp,
-            model_kwargs=model_kwargs,
-        )
+class CachedModel:
+    def __init__(self, cache_path):
+        self.cache_path = cache_path
+        self.cache = None
+        self.cached_sync_funcs = tuple()
+        self.cached_async_funcs = tuple()
 
-    if name.startswith("openrouter"):
+    def load_cache(self):
+        try:
+            with open(self.cache_path, "rb") as cache_file:
+                self.cache = pickle.load(cache_file)
+        except (FileNotFoundError, EOFError):
+            pass
 
-        # Extract the actual model from openrouter/provider/model format
-        parts = name.split("/", 2)
-        if len(parts) < 3:
-            raise ValueError(
-                "OpenRouter model format should be 'openrouter/provider/model'"
+        if self.cache is None:
+            self.cache = {}
+
+    def save_cache(self):
+        os.makedirs(os.path.dirname(self.cache_path), exist_ok=True)
+        with open(self.cache_path, "wb") as cache_file:
+            pickle.dump(self.cache, cache_file)
+
+    @staticmethod
+    async def _arun(coroutine):
+        await coroutine
+        return coroutine
+
+    async def acache_run(self, func: str, *args, **kwargs):
+        if self.cache is None:
+            self.load_cache()
+
+        result = self.cache.get(hashable((func, args, kwargs)))
+
+        if result is None:
+            logger.debug(f"returning without cache: {(func, args, kwargs)}")
+            result = self.model.__getattr__(func)(*args, **kwargs)
+
+            if asyncio.iscoroutine(result):
+                result = await result
+
+            self.cache[hashable((func, args, kwargs))] = result
+            self.save_cache()
+
+        return result
+
+    def cache_run(self, *args, **kwargs):
+        return asyncio.run(self.acache_run(*args, **kwargs))
+
+    def __getattr__(self, attr):
+        if attr in self.cached_async_funcs:
+            return partial(self.acache_run, attr)
+        elif attr in self.cached_sync_funcs:
+            return partial(self.cache_run, attr)
+        else:
+            return self.model.__getattr__(attr)
+
+
+class CachedLLM(CachedModel):
+    def __init__(
+        self,
+        name: str,
+        temp: float = 0.0,
+        enable_logprobs: bool = False,
+        max_tokens: int = 1000,
+        seed: int = 0,
+    ) -> Any:
+
+        """Get a language model instance.
+
+        Args:
+            name: Model name with provider prefix (e.g. "openai/gpt-4o-2024-05-13")
+            temp: Temperature for generation (default: 0.0)
+            enable_logprobs: Whether to enable logprobs for token probabilities (default: False)
+            max_tokens: Maximum tokens to generate (default: 1000)
+
+        Returns:
+            CachedModel-wrapped LogWrapper-wrapped language model instance
+        """
+        super().__init__(cache_path=f"exp/cache/models/{name}_{temp}_{enable_logprobs}_{max_tokens}_{seed}")
+        self.cached_sync_funcs = ("invoke",)
+        self.cached_async_funcs = ("ainvoke",)
+
+        if enable_logprobs:
+            model_kwargs = {"logprobs": True, "top_logprobs": 10}
+        else:
+            model_kwargs = {}
+
+        if name.startswith("openai"):
+            self.model = ChatOpenAI(
+                model=name.split("/")[1],
+                max_tokens=max_tokens,
+                temperature=temp,
+                model_kwargs=model_kwargs,
             )
 
-        # Use the provider/model as the model name for OpenRouter
-        model_id = "/".join(parts[1:])
-
-        # Get the OpenRouter API key from environment variable
-        openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
-        if not openrouter_api_key:
-            raise ValueError(
-                "OPENROUTER_API_KEY environment variable must be set for OpenRouter models"
+        if name.startswith("anthropic"):
+            self.model = ChatAnthropic(
+                model=name.split("/")[1],
+                max_tokens=max_tokens,
+                temperature=temp,
+                model_kwargs=model_kwargs,
             )
 
-        return ChatOpenAI(
-            model=model_id,
-            max_tokens=max_tokens,
-            temperature=temp,
-            openai_api_key=openrouter_api_key,  # Use the OpenRouter API key
-            openai_api_base="https://openrouter.ai/api/v1",
-            default_headers=OPENROUTER_HEADERS,
-            model_kwargs=model_kwargs,
-        )
+        if name.startswith("openrouter"):
+
+            # Extract the actual model from openrouter/provider/model format
+            parts = name.split("/", 2)
+            if len(parts) < 3:
+                raise ValueError(
+                    "OpenRouter model format should be 'openrouter/provider/model'"
+                )
+
+            # Use the provider/model as the model name for OpenRouter
+            model_id = "/".join(parts[1:])
+
+            # Get the OpenRouter API key from environment variable
+            openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+            if not openrouter_api_key:
+                raise ValueError(
+                    "OPENROUTER_API_KEY environment variable must be set for OpenRouter models"
+                )
+
+            self.model = ChatOpenAI(
+                model=model_id,
+                max_tokens=max_tokens,
+                temperature=temp,
+                openai_api_key=openrouter_api_key,  # Use the OpenRouter API key
+                openai_api_base="https://openrouter.ai/api/v1",
+                default_headers=OPENROUTER_HEADERS,
+                model_kwargs=model_kwargs,
+            )
 
 
-def get_embeddings_model(name):
-    # TODO: support other embeddings?
+class CachedEmbeddingsModel(CachedModel):
+    def __init__(
+        self,
+        name: str,
+        seed: int = 0,
+    ):
+        # TODO: support other embeddings?
 
-    openrouter = name.startswith("openrouter")
-    openai_api_key = os.environ.get("OPENAI_API_KEY")
+        super().__init__(cache_path=f"exp/cache/models/{name}_{seed}")
 
-    if openrouter and not openai_api_key:
-        raise ValueError(
-            "OpenRouter doesn't support embedding models, OPENAI_API_KEY still required"
-        )
+        openrouter = name.startswith("openrouter")
+        openai_api_key = os.environ.get("OPENAI_API_KEY")
 
-    return OpenAIEmbeddings()
+        if openrouter and not openai_api_key:
+            raise ValueError(
+                "OpenRouter doesn't support embedding models, OPENAI_API_KEY still required"
+            )
+
+        self.model = OpenAIEmbeddings()
+
+
+# compatibility
+def get_model(*args, **kwargs):
+    return CachedLLM(*args, **kwargs)
+
+def get_embeddings_model(*args, **kwargs):
+    return CachedEmbeddingsModel(*args, **kwargs)
 
 
 def get_token_probs(tokens: list[str], model: str, messages: list) -> dict[float]:

--- a/src/inverse_cai/models.py
+++ b/src/inverse_cai/models.py
@@ -11,6 +11,7 @@ import os
 import os.path
 import hashlib
 
+from functools import lru_cache
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_anthropic import ChatAnthropic
 from langchain_community.callbacks import get_openai_callback
@@ -71,38 +72,27 @@ def partial_hash(obj):
         return f"hash:{hash_obj(obj)[:8]}"
 
 
-class CachedModel:
-
-    def __init__(self, cache_dir, seed=0):
+class CachedObject:
+    def __init__(self, obj, cache_dir, cached_funcs, seed=0):
+        self.obj = obj
         self.cache_dir = cache_dir
-        self.cache = None
-        self.cached_sync_funcs = tuple()
-        self.cached_async_funcs = tuple()
+        self.cached_funcs = cached_funcs
         self.seed = seed
 
-    @property
-    def cache_path(self):
-        return f"{self.cache_dir}/{self.seed}.pkl"
+    def cache_key_path(self, key):
+        return f"{self.cache_dir}/{self.seed}/{key}.pkl"
 
-    def load_cache(self):
-        try:
-            with open(self.cache_path, "rb") as cache_file:
-                file_cache = pickle.load(cache_file)
-        except (FileNotFoundError, EOFError):
-            file_cache = {}
+    @lru_cache(maxsize=128)
+    def get_from_cache(self, key):
+        if os.path.isfile(self.cache_key_path(key)):
+            with open(self.cache_key_path(key), "rb") as cache_file:
+                return pickle.load(cache_file)
 
-        if self.cache is None:
-            self.cache = {}
+        return None
 
-        self.cache = file_cache | self.cache
-
-    def save_cache(self):
-        os.makedirs(self.cache_dir, exist_ok=True)
-
-        with FileLock(self.cache_path + ".lock"):
-            self.load_cache()
-            with open(self.cache_path, "wb") as cache_file:
-                pickle.dump(self.cache, cache_file)
+    def save_to_cache(self, key, value):
+        with open(self.cache_key_path(key), "wb") as cache_file:
+            pickle.dump(value, cache_file)
 
     @staticmethod
     async def _arun(coroutine):
@@ -110,22 +100,17 @@ class CachedModel:
         return coroutine
 
     async def async_cache_run(self, func: str, *args, **kwargs):
-        if self.cache is None:
-            self.load_cache()
-
         h = hash_obj((func, args, kwargs))
-        result = self.cache.get(h)
+        result = self.get_from_cache(h)
 
         if result is None:
             logger.debug(f"cache {self.seed} miss ({h[:8]})")
-            result = getattr(self.model, func)(*args, **kwargs)
+            result = getattr(self.obj, func)(*args, **kwargs)
 
             if asyncio.iscoroutine(result):
                 result = await result
 
-            self.cache[h] = result
-            self.save_cache()
-
+            self.save_to_cache(h, result)
         else:
             logger.debug(f"cache {self.seed} hit ({h[:8]})")
 
@@ -135,121 +120,122 @@ class CachedModel:
         return asyncio.run(self.async_cache_run(*args, **kwargs))
 
     def __getattr__(self, attr):
-        if attr in self.cached_async_funcs:
-            return partial(self.async_cache_run, attr)
-        elif attr in self.cached_sync_funcs:
-            return partial(self.cache_run, attr)
+        if attr in self.cached_funcs:
+            if asyncio.iscoroutinefunction(getattr(self.obj, attr)):
+                return partial(self.async_cache_run, attr)
+            else:
+                return partial(self.cache_run, attr)
         else:
-            return self.model.__getattr__(attr)
+            return self.obj.__getattr__(attr)
 
 
-class CachedLLM(CachedModel):
-    def __init__(
-        self,
-        name: str,
-        temp: float = 0.0,
-        enable_logprobs: bool = False,
-        max_tokens: int = 1000,
-        **kwargs,
-    ) -> Any:
-        """Get a language model instance.
+def get_model(
+    name: str,
+    temp: float = 0.0,
+    enable_logprobs: bool = False,
+    max_tokens: int = 1000,
+    cache: bool = True,
+    cache_seed: int = 0,
+) -> Any:
+    """Get a language model instance.
 
-        Args:
-            name: Model name with provider prefix (e.g. "openai/gpt-4o-2024-05-13")
-            temp: Temperature for generation (default: 0.0)
-            enable_logprobs: Whether to enable logprobs for token probabilities (default: False)
-            max_tokens: Maximum tokens to generate (default: 1000)
+    Args:
+        name: Model name with provider prefix (e.g. "openai/gpt-4o-2024-05-13")
+        temp: Temperature for generation (default: 0.0)
+        enable_logprobs: Whether to enable logprobs for token probabilities (default: False)
+        max_tokens: Maximum tokens to generate (default: 1000)
+        cache: enable model cache
 
-        Returns:
-            CachedModel-wrapped LogWrapper-wrapped language model instance
-        """
-        super().__init__(
-            cache_dir=f"exp/cache/models/{name}_{temp}_{enable_logprobs}_{max_tokens}",
-            **kwargs,
+    Returns:
+        (possibly CachedObject-wrapped) LogWrapper-wrapped language model instance
+    """
+    if enable_logprobs:
+        model_kwargs = {"logprobs": True, "top_logprobs": 10}
+    else:
+        model_kwargs = {}
+
+    if name.startswith("openai"):
+        model = ChatOpenAI(
+            model=name.split("/")[1],
+            max_tokens=max_tokens,
+            temperature=temp,
+            model_kwargs=model_kwargs,
         )
-        self.cached_sync_funcs = ("invoke",)
-        self.cached_async_funcs = ("ainvoke",)
 
-        if enable_logprobs:
-            model_kwargs = {"logprobs": True, "top_logprobs": 10}
-        else:
-            model_kwargs = {}
+    elif name.startswith("anthropic"):
+        model = ChatAnthropic(
+            model=name.split("/")[1],
+            max_tokens=max_tokens,
+            temperature=temp,
+            model_kwargs=model_kwargs,
+        )
 
-        if name.startswith("openai"):
-            self.model = ChatOpenAI(
-                model=name.split("/")[1],
-                max_tokens=max_tokens,
-                temperature=temp,
-                model_kwargs=model_kwargs,
-            )
-
-        if name.startswith("anthropic"):
-            self.model = ChatAnthropic(
-                model=name.split("/")[1],
-                max_tokens=max_tokens,
-                temperature=temp,
-                model_kwargs=model_kwargs,
-            )
-
-        if name.startswith("openrouter"):
-
-            # Extract the actual model from openrouter/provider/model format
-            parts = name.split("/", 2)
-            if len(parts) < 3:
-                raise ValueError(
-                    "OpenRouter model format should be 'openrouter/provider/model'"
-                )
-
-            # Use the provider/model as the model name for OpenRouter
-            model_id = "/".join(parts[1:])
-
-            # Get the OpenRouter API key from environment variable
-            openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
-            if not openrouter_api_key:
-                raise ValueError(
-                    "OPENROUTER_API_KEY environment variable must be set for OpenRouter models"
-                )
-
-            self.model = ChatOpenAI(
-                model=model_id,
-                max_tokens=max_tokens,
-                temperature=temp,
-                openai_api_key=openrouter_api_key,  # Use the OpenRouter API key
-                openai_api_base="https://openrouter.ai/api/v1",
-                default_headers=OPENROUTER_HEADERS,
-                model_kwargs=model_kwargs,
-            )
-
-
-class CachedEmbeddingsModel(CachedModel):
-    def __init__(
-        self,
-        name: str,
-        **kwargs,
-    ):
-        # TODO: support other embeddings?
-
-        super().__init__(cache_dir=f"exp/cache/models/{name}", **kwargs)
-        self.cached_sync_funcs = ("embed_documents",)
-
-        openrouter = name.startswith("openrouter")
-        openai_api_key = os.environ.get("OPENAI_API_KEY")
-
-        if openrouter and not openai_api_key:
+    elif name.startswith("openrouter"):
+        # Extract the actual model from openrouter/provider/model format
+        parts = name.split("/", 2)
+        if len(parts) < 3:
             raise ValueError(
-                "OpenRouter doesn't support embedding models, OPENAI_API_KEY still required"
+                "OpenRouter model format should be 'openrouter/provider/model'"
             )
 
-        self.model = OpenAIEmbeddings()
+        # Use the provider/model as the model name for OpenRouter
+        model_id = "/".join(parts[1:])
+
+        # Get the OpenRouter API key from environment variable
+        openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not openrouter_api_key:
+            raise ValueError(
+                "OPENROUTER_API_KEY environment variable must be set for OpenRouter models"
+            )
+
+        model = ChatOpenAI(
+            model=model_id,
+            max_tokens=max_tokens,
+            temperature=temp,
+            openai_api_key=openrouter_api_key,  # Use the OpenRouter API key
+            openai_api_base="https://openrouter.ai/api/v1",
+            default_headers=OPENROUTER_HEADERS,
+            model_kwargs=model_kwargs,
+        )
+    else:
+        raise ValueError(f"{name} is not a recognised model name")
+
+    if cache:
+        model = CachedObject(
+            model,
+            cache_dir=f"exp/cache/models/{name}_{temp}_{enable_logprobs}_{max_tokens}",
+            cached_funcs=("invoke", "ainvoke"),
+            seed=cache_seed,
+        )
+
+    return model
 
 
-# compatibility
-def get_model(*args, **kwargs):
-    return CachedLLM(*args, **kwargs)
+def get_embeddings_model(
+    self,
+    name: str,
+    cache: bool = True,
+    cache_seed: int = 0,
+):
+    openrouter = name.startswith("openrouter")
+    openai_api_key = os.environ.get("OPENAI_API_KEY")
 
+    if openrouter and not openai_api_key:
+        raise ValueError(
+            "OpenRouter doesn't support embedding models, OPENAI_API_KEY still required"
+        )
 
-def get_embeddings_model(*args, **kwargs):
-    return CachedEmbeddingsModel(*args, **kwargs)
+    model = OpenAIEmbeddings()
+
+    if cache:
+        model = CachedObject(
+            model,
+            cache_dir=f"exp/cache/models/{name}",
+            cached_funcs=("embed_documents",),
+            seed=cache_seed,
+        )
+
+    return model
 
 
 def get_token_probs(tokens: list[str], model: str, messages: list) -> dict[float]:


### PR DESCRIPTION
- Model calls are wrapped in a global cache (seed can be set to use multiple caches).
- This cache can (in theory) be enabled for any function, sync or async, on any model.
- Function inputs are best-effort serialised (falling back to string) and then hashed as a key into the cache.
- Function outputs must be pickleable.
- Because the cache is at the LLM-invocation level, calling the model with data permuted before then (e.g. samples being given in a different random order) result in a cache miss (bad)