### PR TITLE
Add support for AnnotatedPairs JSON input and minor fixes

### DIFF
--- a/data/processed/example/example_ap.json
+++ b/data/processed/example/example_ap.json
@@ -1,0 +1,63 @@
+{
+  "metadata": {
+    "version": "2.0",
+    "description": "Annotated pairs dataset with annotations from ICAI\n\nIncluding annotations by function annotators.",
+    "created_at": "2025-08-22T17:29:21Z",
+    "dataset_name": "ICAI Training Dataset - 2025-08-22_17-29-16_Dataset with annotations by evaluated annotators - training data",
+    "default_annotator": "ba751e7b",
+    "available_metadata_keys_per_comparison": [
+      "index"
+    ]
+  },
+  "annotators": {
+    "ba751e7b": {
+      "name": "preferred_text",
+      "description": "Default annotator from original dataset (from column `preferred_text`)",
+      "type": "unknown"
+    },
+    "2f45a6d0": {
+      "description": "Select the response that evokes a sense of mystery.",
+      "type": "principle"
+    },
+    "fafd12b9": {
+      "description": "Select the response that highlights a unique character trait.",
+      "type": "principle"
+    },
+    "435cef52": {
+      "description": "Select the response that features a more adventurous setting.",
+      "type": "principle"
+    }
+  },
+  "comparisons": [
+    {
+      "id": "4b49a6e7",
+      "prompt": "Write a short story about a pet.",
+      "response_a": {
+        "text": "In the heart of a bustling city, a sleek black cat named Shadow prowled the moonlit rooftops, her eyes gleaming with curiosity and mischief. She discovered a hidden garden atop an old apartment building, where she danced under the stars, chasing fireflies that glowed like tiny lanterns. As dawn painted the sky in hues of orange and pink, Shadow found her way back home, carrying the secret of the garden in her heart.",
+        "model": "Model X"
+      },
+      "response_b": {
+        "text": "Across the town, in a cozy neighborhood, a golden retriever named Buddy embarked on his daily adventure, tail wagging with uncontainable excitement. He found a lost toy under the bushes in the park, its colors faded and fabric worn, but to Buddy, it was a treasure untold. Returning home with his newfound prize, Buddy's joyful barks filled the air, reminding everyone in the house that happiness can be found in the simplest of things.",
+        "model": "Model Y"
+      },
+      "annotations": {
+        "ba751e7b": {
+          "pref": "a"
+        },
+        "2f45a6d0": {
+          "pref": "a"
+        },
+        "fafd12b9": {
+          "pref": null,
+          "no_pref_reason": "not_applicable"
+        },
+        "435cef52": {
+          "pref": "a"
+        }
+      },
+      "metadata": {
+        "index": "0"
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inverse-cai"
-version = "0.4.3"
+version = "0.4.4"
 authors = [
   { name="rdnfn", email="hi@arduin.io" },
   { name="timokau", email="" },
@@ -69,7 +69,7 @@ line-length = 88
 target-version = ['py311']
 
 [tool.bumpversion]
-current_version = "0.4.3"
+current_version = "0.4.4"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/inverse_cai/algorithm/main.py
+++ b/src/inverse_cai/algorithm/main.py
@@ -77,7 +77,7 @@ def run(
     if not config.s0_skip_principle_generation:
         ### STAGE 1: Generate principles from feedback
         logger.info("Stage 1: Generate principles from feedback")
-        feedback, principles, is_prompt_principles = generate_principles_from_feedback(
+        feedback, principles, prompt_principles = generate_principles_from_feedback(
             feedback=feedback,
             num_principles_per_sampling_step=num_principles_per_sampling_step,
             model_name=model_name,
@@ -99,11 +99,9 @@ def run(
         print("Principles:")
         print("\n".join(principles))
         print("Prompt Principles:")
-        print("\n".join(is_prompt_principles))
+        print("\n".join(prompt_principles))
         save_to_json(principles, save_path / "011_principles_list.json")
-        save_to_json(
-            is_prompt_principles, save_path / "016_prompt_principles_list.json"
-        )
+        save_to_json(prompt_principles, save_path / "016_prompt_principles_list.json")
 
         ### STAGE 2: Cluster principles
         logger.info("Stage 2: Cluster principles")
@@ -124,7 +122,7 @@ def run(
         print_clusters(clusters, summaries)
 
         prompt_clusters = cluster_principles(
-            is_prompt_principles,
+            prompt_principles,
             num_clusters=num_clusters,
             model_name=model_name,
             random_clusters=random_clusters,

--- a/src/inverse_cai/algorithm/proposal.py
+++ b/src/inverse_cai/algorithm/proposal.py
@@ -164,6 +164,12 @@ async def generate_principles_from_single_ranking(
     model = inverse_cai.models.get_model(model_name)
     principless: list = []
 
+    # Allows disabling prompt principle generation entirely
+    if config.s3_skip_prompt_principle_generation:
+        prompt_generator_prompts = []
+    else:
+        prompt_generator_prompts = config.alg_prompts.prompt_generator_prompts
+
     for generator, kwargs, optional_kwargs in [
         (
             config.alg_prompts.generator_prompts,
@@ -175,7 +181,7 @@ async def generate_principles_from_single_ranking(
             dict(),
         ),
         (
-            config.alg_prompts.prompt_generator_prompts,
+            prompt_generator_prompts,
             dict(
                 prompt=prompt,
                 num_principles=num_principles,

--- a/src/inverse_cai/data/loader/standard.py
+++ b/src/inverse_cai/data/loader/standard.py
@@ -1,6 +1,8 @@
 """Functions for loading standard preference data."""
 
 import pandas as pd
+import json
+import pathlib
 from loguru import logger
 
 REQUIRED_COLUMNS = ["text_a", "text_b"]
@@ -26,7 +28,7 @@ def switch_pref_labels_in_df(df):
 
 
 def load(
-    path: str, switch_labels: bool = False, merge_prompts: bool = True
+    path: str | pathlib.Path, switch_labels: bool = False, merge_prompts: bool = True
 ) -> pd.DataFrame:
     """
     Load the standard preference data from a CSV file.
@@ -35,8 +37,14 @@ def load(
         path (str): The path to the CSV file.
     """
 
-    # Load the CSV file
-    df = pd.read_csv(path)
+    path = pathlib.Path(path)
+
+    if path.suffix == ".csv":
+        df = pd.read_csv(path)
+    elif path.suffix == ".json":
+        df = _load_from_ap_json(path)
+    else:
+        raise ValueError(f"Unsupported file extension: {path.suffix}")
 
     # Check that the required columns are present
     missing_columns = set(REQUIRED_COLUMNS) - set(df.columns)
@@ -52,6 +60,47 @@ def load(
     if switch_labels:
         df = switch_pref_labels_in_df(df)
 
+    return df
+
+
+def _load_from_ap_json(
+    path: str,
+    force_pref_text_validation: bool = False,
+) -> pd.DataFrame:
+    """
+    Load the standard preference data from a AnnotatedPairs JSON file.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        ap_data = json.load(f)
+
+    default_annotator = ap_data["metadata"]["default_annotator"]
+
+    ap_version = ap_data["metadata"]["version"]
+    if ap_version in ["1.0"]:
+        raise ValueError(
+            f"Loading from AnnotatedPairs (AP) {ap_version} is currently not supported, only from AP v2.0 or higher."
+        )
+
+    # Transform from AnnotatedPairs JSON format to simple CSV dataframe
+    rows = []
+    for comparison in ap_data["comparisons"]:
+        pref_text = comparison["annotations"].get(default_annotator, {}).get("pref")
+        pref_text = pref_text.replace("a", "text_a").replace("b", "text_b")
+        rows.append(
+            {
+                "id": comparison["id"],
+                "prompt": comparison["prompt"],
+                "text_a": comparison["response_a"]["text"],
+                "text_b": comparison["response_b"]["text"],
+                "preferred_text": pref_text,
+            }
+        )
+
+    df = pd.DataFrame(rows)
+    if force_pref_text_validation and df["preferred_text"].isna().all():
+        raise ValueError(
+            "No preferred text found during ICAI run, cannot generate principles (because no target)."
+        )
     return df
 
 

--- a/src/inverse_cai/experiment/config/main.py
+++ b/src/inverse_cai/experiment/config/main.py
@@ -213,6 +213,9 @@ class ExpConfig:
     s3_ratio_of_max_principles_to_cluster_again: float = (
         1.5  # proportion of max_principles to sample from filtered principle to then cluster again (until finally getting max principles)
     )
+    # Whether to skip prompt principle generation entirely
+    # (will create empty prompt principles list)
+    s3_skip_prompt_principle_generation: bool = True
 
     # Stage 9: AI judgment
     annotator: Optional[AnnotatorConfig] = field(default_factory=AnnotatorConfig)

--- a/src/inverse_cai/experiment/core_test.py
+++ b/src/inverse_cai/experiment/core_test.py
@@ -12,14 +12,17 @@ TEST_API_MODEL = "openrouter/openai/gpt-4o-mini-2024-07-18"
 @pytest.mark.parametrize(
     "additional_args",
     [
-        [],
+        ["data_path=data/processed/example/example.csv"],
+        ["data_path=data/processed/example/example_ap.json"],
         [
+            "data_path=data/processed/example/example.csv"
             "s0_added_principles_to_test=[test_principle1,test_principle2]",
             "s0_added_standard_principles_to_test=[v1,v2]",
             "annotator.fn_annotators=[{function:'inverse_cai.annotators.dummy.annotate_perfectly'}]",
         ],
         [
             # test that uses ICAI for Feedback Forensics use-case
+            "data_path=data/processed/example/example.csv"
             "s0_added_standard_principles_to_test=[v4]",
             "annotator.skip=true",
             "s0_skip_principle_generation=true",
@@ -31,7 +34,6 @@ def test_cli_minimal_experiment(additional_args: list[str]):
     # Run the CLI command in a subprocess
     cmd = [
         "icai-exp",
-        "data_path=data/processed/example/example.csv",
         f"alg_model={TEST_API_MODEL}",
         *additional_args,
     ]

--- a/src/inverse_cai/experiment/core_test.py
+++ b/src/inverse_cai/experiment/core_test.py
@@ -15,14 +15,14 @@ TEST_API_MODEL = "openrouter/openai/gpt-4o-mini-2024-07-18"
         ["data_path=data/processed/example/example.csv"],
         ["data_path=data/processed/example/example_ap.json"],
         [
-            "data_path=data/processed/example/example.csv"
+            "data_path=data/processed/example/example.csv",
             "s0_added_principles_to_test=[test_principle1,test_principle2]",
             "s0_added_standard_principles_to_test=[v1,v2]",
             "annotator.fn_annotators=[{function:'inverse_cai.annotators.dummy.annotate_perfectly'}]",
         ],
         [
             # test that uses ICAI for Feedback Forensics use-case
-            "data_path=data/processed/example/example.csv"
+            "data_path=data/processed/example/example.csv",
             "s0_added_standard_principles_to_test=[v4]",
             "annotator.skip=true",
             "s0_skip_principle_generation=true",


### PR DESCRIPTION
- Add support for AP JSON data as experiment input
- Fixes issue where cache generated for prompt principles
- Make generating prompt principle optional and configurable (via `cfg.s3_skip_prompt_principle_generation`). This parameter is now set by default to True (to avoid generating unused prompt principles in standard ICAI experiments).