### PR TITLE
Misc updates to voting functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inverse-cai"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
   { name="rdnfn", email="hi@arduin.io" },
   { name="timokau", email="" },
@@ -69,7 +69,7 @@ line-length = 88
 target-version = ['py311']
 
 [tool.bumpversion]
-current_version = "0.4.4"
+current_version = "0.4.5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/inverse_cai/algorithm/voting.py
+++ b/src/inverse_cai/algorithm/voting.py
@@ -287,7 +287,9 @@ async def get_preference_vote_for_messages(
     numbered_principles: dict,
     valid_values: dict,
 ):
-    model = inverse_cai.models.get_model(model_name)
+    model = inverse_cai.models.get_model(
+        model_name, max_tokens=config.s3_voting_max_output_tokens
+    )
 
     vote = None
     try:

--- a/src/inverse_cai/data/loader/standard.py
+++ b/src/inverse_cai/data/loader/standard.py
@@ -92,6 +92,8 @@ def _load_from_ap_json(
                 "prompt": comparison["prompt"],
                 "text_a": comparison["response_a"]["text"],
                 "text_b": comparison["response_b"]["text"],
+                "model_a": comparison["response_a"].get("model", None),
+                "model_b": comparison["response_b"].get("model", None),
                 "preferred_text": pref_text,
             }
         )

--- a/src/inverse_cai/experiment/config/main.py
+++ b/src/inverse_cai/experiment/config/main.py
@@ -202,6 +202,7 @@ class ExpConfig:
         3  # how often to re-annotate the same data to combine into final vote
     )
     s3_voting_method_cross_seed: str = "unanimous"  # one of "majority", "unanimous"
+    s3_voting_max_output_tokens: int = 3000
     s3_filter_majority_true: bool = True
     s3_filter_majority_relevant: bool = False
     s3_filter_majority_valid: bool = True


### PR DESCRIPTION
* Catch problems with vote end reason (e.g. because length stop). This is especially helpful with thinking models that may produce more tokens for voting.
* Add model to AP json loader to ensure hash keys stay consistent
* Make max token usage configurable (and increase from 1k to 3k)