### PR TITLE
Remove loading of alpaca eval in algorithm utils module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inverse-cai"
-version = "0.4.6"
+version = "0.4.7"
 authors = [
   { name="rdnfn", email="hi@arduin.io" },
   { name="timokau", email="" },
@@ -69,7 +69,7 @@ line-length = 88
 target-version = ['py311']
 
 [tool.bumpversion]
-current_version = "0.4.6"
+current_version = "0.4.7"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "loguru",
   "hydra-core",
   "matplotlib",
-  "setuptools", # for alpaca-eval
+  "setuptools<81", # for alpaca-eval
   "backoff",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "loguru",
   "hydra-core",
   "matplotlib",
-  "setuptools<81", # for alpaca-eval
+  "setuptools<81", # for alpaca-eval, which requires pkg_resources, which in turn has been removed from setuptool >=81
   "backoff",
 ]
 

--- a/src/inverse_cai/algorithm/utils.py
+++ b/src/inverse_cai/algorithm/utils.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from loguru import logger
 from typing import Awaitable
 import openai
-import alpaca_eval.utils
 import backoff
 import logging
 import re
@@ -29,7 +28,7 @@ def parse_prompt(
             logger.error(f"Key '{key}' is not a valid key. Check your prompts.")
             prompt_str = prompt_str.replace(f"{{{key}}}", "")
 
-    messages = alpaca_eval.utils.prompt_to_chatml(prompt_str)
+    messages = ae_prompt_to_chatml(prompt_str)
 
     # add values to individual messages AFTER prompt to chatml
     # note: this is necessary if prompt_kwargs contain chatml syntax
@@ -165,3 +164,81 @@ def _fatal_model_error(err):
 )
 async def run_with_http_retries(fn, *args, **kwargs):
     return await fn(*args, **kwargs)
+
+
+# The following two functions (string_to_dict and prompt_to_chatml) are taken from alpaca_eval.utils
+# Replicated here to reduce dependency on alpaca_eval
+# Licensed under Apache License 2.0 (https://github.com/tatsu-lab/alpaca_eval/blob/cd543a149df89434d8a54582c0151c0b945c3d20/LICENSE)
+# Copyright 2023 Yann Dubois and Xuechen Li and Rohan Taori and Tianyi Zhang and Ishaan Gulrajani
+
+
+def ae_string_to_dict(to_convert):
+    r"""Converts a string with equal signs to dictionary. E.g.
+    >>> _string_to_dict(" name=user university=stanford")
+    {'name': 'user', 'university': 'stanford'}
+    """
+    return {
+        s.split("=", 1)[0]: s.split("=", 1)[1]
+        for s in to_convert.split(" ")
+        if len(s) > 0
+    }
+
+
+def ae_prompt_to_chatml(
+    prompt: str, start_token: str = "<|im_start|>", end_token: str = "<|im_end|>"
+):
+    r"""Convert a text prompt to ChatML formal
+
+    Examples
+    --------
+    >>> prompt = (
+    ... "<|im_start|>system\n"
+    ... "You are a helpful assistant.\n<|im_end|>\n"
+    ... "<|im_start|>system name=example_user\nKnock knock.\n<|im_end|>\n<|im_start|>system name=example_assistant\n"
+    ... "Who's there?\n<|im_end|>\n<|im_start|>user\nOrange.\n<|im_end|>"
+    ... )
+    >>> print(prompt)
+    <|im_start|>system
+    You are a helpful assistant.
+    <|im_end|>
+    <|im_start|>system name=example_user
+    Knock knock.
+    <|im_end|>
+    <|im_start|>system name=example_assistant
+    Who's there?
+    <|im_end|>
+    <|im_start|>user
+    Orange.
+    <|im_end|>
+    >>> prompt_to_chatml(prompt)
+    [{'content': 'You are a helpful assistant.', 'role': 'system'},
+      {'content': 'Knock knock.', 'role': 'system', 'name': 'example_user'},
+      {'content': "Who's there?", 'role': 'system', 'name': 'example_assistant'},
+      {'content': 'Orange.', 'role': 'user'}]
+    """
+    prompt = prompt.strip()
+    assert prompt.startswith(start_token)
+    assert prompt.endswith(end_token)
+
+    message = []
+    for p in prompt.split("<|im_start|>")[1:]:
+        newline_splitted = p.split("\n", 1)
+        role = newline_splitted[0].strip()
+        content = newline_splitted[1].split(end_token, 1)[0].strip()
+
+        if role.startswith("system") and role != "system":
+            # based on https://github.com/openai/openai-cookbook/blob/main/examples
+            # /How_to_format_inputs_to_ChatGPT_models.ipynb
+            # and https://github.com/openai/openai-python/blob/main/chatml.md it seems that system can specify a
+            # dictionary of other args
+            other_params = ae_string_to_dict(role.split("system", 1)[-1])
+            role = "system"
+        else:
+            other_params = dict()
+
+        message.append(dict(content=content, role=role, **other_params))
+
+    return message
+
+
+## End of AE functions

--- a/src/inverse_cai/data/annotated_pairs_format.py
+++ b/src/inverse_cai/data/annotated_pairs_format.py
@@ -269,7 +269,7 @@ def create_annotated_pairs(
     }
 
     df = df.copy()
-    df = df.applymap(str)  # ensure all columns are hashable
+    df = df.astype(str)  # ensure all columns are hashable
 
     # Detect annotator columns if enabled
     detected_columns = []

--- a/src/inverse_cai/data/loader/anthropic.py
+++ b/src/inverse_cai/data/loader/anthropic.py
@@ -93,7 +93,7 @@ def limit_text_length(df: pd.DataFrame, max_text_length: int) -> pd.DataFrame:
     """
     Limits the text length in the data frame to the given maximum text length.
     """
-    return df[df.applymap(str).applymap(len).lt(max_text_length).all(axis=1)]
+    return df[df.map(str).map(len).lt(max_text_length).all(axis=1)]
 
 
 def switch_labels_in_df(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
Plus some other small updates to ensure compatibility with current package versions

Note to beyond existing compatibility commits, API tests require both openrouter and openai API keys being available.